### PR TITLE
Unify Network Schemas

### DIFF
--- a/src/modules/device.json
+++ b/src/modules/device.json
@@ -513,19 +513,7 @@
         "name": "networkInfo",
         "summary": "the status and type",
         "schema": {
-          "type": "object",
-          "properties": {
-            "state": {
-              "$ref": "#/components/schemas/NetworkState"
-            },
-            "type": {
-              "$ref": "#/components/schemas/NetworkType"
-            }
-          },
-          "required": [
-            "state",
-            "type"
-          ]
+          "$ref": "https://meta.comcast.com/firebolt/network#/definitions/NetworkStatus"
         }
       },
       "examples": [
@@ -558,25 +546,6 @@
         "additionalItems": false,
         "minItems": 2,
         "maxItems": 2
-      },
-      "NetworkType": {
-        "title": "NetworkType",
-        "type": "string",
-        "enum": [
-          "wifi",
-          "ethernet",
-          "hybrid"
-        ],
-        "description": "The type of network that is currently active"
-      },
-      "NetworkState": {
-        "title": "NetworkState",
-        "type": "string",
-        "enum": [
-          "connected",
-          "disconnected"
-        ],
-        "description": "The type of network that is currently active"
       },
       "AudioProfiles": {
         "title": "AudioProfiles",


### PR DESCRIPTION
Core's Device.network() API returns:

```
{
  state: 'connected' | 'disconnected',
  type: 'wifi' | 'ethernet' | 'hybrid'
}
```

And Manage returns:

```
{
  connection: true | false,
  interface: 'wifi' | 'ethernet' | 'none'
}
```

We can't change Core... It's being used by apps, but we can add values to the fields in Manage, and rename the fields to match:

```
{
  connected: true | false
  state: 'connected' | 'disconnected',
  type: 'wifi' | 'ethernet' | 'hybrid' | 'none'
}
```

Related PR:
https://github.com/rdkcentral/firebolt-schemas/pull/9