### PR TITLE
fix: Add enumerated values for fontFamily/fontEdge

### DIFF
--- a/src/openrpc/accessibility.json
+++ b/src/openrpc/accessibility.json
@@ -39,7 +39,7 @@
             "value": {
               "enabled": true,
               "styles": {
-                "fontFamily": "Monospace sans-serif",
+                "fontFamily": "monospaced_sanserif",
                 "fontSize": 1,
                 "fontColor": "#ffffff",
                 "fontEdge": "none",
@@ -92,7 +92,7 @@
             "value": {
               "enabled": true,
               "styles": {
-                "fontFamily": "Monospace sans-serif",
+                "fontFamily": "monospaced_sanserif",
                 "fontSize": 1,
                 "fontColor": "#ffffff",
                 "fontEdge": "none",

--- a/src/openrpc/closed_captions.json
+++ b/src/openrpc/closed_captions.json
@@ -73,7 +73,7 @@
                     "params": [],
                     "result": {
                         "name": "family",
-                        "value": "monospace"
+                        "value": "monospaced_sanserif"
                     }
                 },
                 {
@@ -225,7 +225,7 @@
                     "params": [],
                     "result": {
                         "name": "edge",
-                        "value": "solid"
+                        "value": "uniform"
                     }
                 },
                 {

--- a/src/schemas/accessibility.json
+++ b/src/schemas/accessibility.json
@@ -11,14 +11,33 @@
     ],
     "definitions": {
         "FontFamily": {
-            "type": ["string", "null"]
+            "type": ["string", "null"],
+            "enum": [
+                "monospaced_serif",
+                "proportional_serif",
+                "monospaced_sanserif",
+                "proportional_sanserif",
+                "smallcaps",
+                "cursive",
+                "casual",
+                null
+            ]
         },
         "FontSize": {
             "type": ["number", "null"],
             "minimum": 0
         },
         "FontEdge": {
-            "type": ["string", "null"]
+            "type": ["string", "null"],
+            "enum": [
+                "none",
+                "raised",
+                "depressed",
+                "uniform",
+                "drop_shadow_left",
+                "drop_shadow_right",
+                null
+            ]
         },
         "Color": {
             "type": ["string", "null"]

--- a/src/schemas/accessibility.json
+++ b/src/schemas/accessibility.json
@@ -122,7 +122,7 @@
                 {
                     "enabled": true,
                     "styles": {
-                        "fontFamily": "Monospace sans-serif",
+                        "fontFamily": "monospaced_serif",
                         "fontSize": 1,
                         "fontColor": "#ffffff",
                         "fontEdge": "none",

--- a/src/sdks/manage/test/suite/closedCaptions.test.ts
+++ b/src/sdks/manage/test/suite/closedCaptions.test.ts
@@ -27,7 +27,7 @@ test("ClosedCaptions.enabled()", () => {
 
 test("ClosedCaptions.fontFamily()", () => {
   return ClosedCaptions.fontFamily().then((res: string) => {
-    expect(res).toEqual("monospace");
+    expect(res).toEqual("monospaced_sanserif");
   });
 });
 


### PR DESCRIPTION
Adds the following allowed values for fontFamily and fontEdge:

```json
            "enum": [
                "monospaced_serif",
                "proportional_serif",
                "monospaced_sanserif",
                "proportional_sanserif",
                "smallcaps",
                "cursive",
                "casual",
                null
            ]
```
and
```json
            "enum": [
                "none",
                "raised",
                "depressed",
                "uniform",
                "drop_shadow_left",
                "drop_shadow_right",
                null
            ]
```