### PR TITLE
fix: Spec and Doc fixes for Release 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16962,7 +16962,7 @@
     },
     "src/sdks/core": {
       "name": "@firebolt-js/sdk",
-      "version": "1.3.0-next.3",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^28.1.0",
@@ -16973,7 +16973,7 @@
     },
     "src/sdks/discovery": {
       "name": "@firebolt-js/discovery-sdk",
-      "version": "1.3.0-next.3",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^28.1.0",
@@ -16984,7 +16984,7 @@
     },
     "src/sdks/manage": {
       "name": "@firebolt-js/manage-sdk",
-      "version": "1.3.0-next.3",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^28.1.0",

--- a/src/json/firebolt-specification.json
+++ b/src/json/firebolt-specification.json
@@ -147,9 +147,6 @@
         "negotiable": false
       }
     },
-    "xrn:firebolt:capability:privacy:advertising": {
-      "level": "could"
-    },
     "xrn:firebolt:capability:metrics:distributor": {
       "level": "could"
     },

--- a/src/openrpc/_internal.json
+++ b/src/openrpc/_internal.json
@@ -35,15 +35,7 @@
         "name": "session",
         "summary": "Info about the SDK/FEE session",
         "schema": {
-          "type": "object",
-          "required": ["version"],
-          "properties": {
-            "version": {
-              "$ref": "https://meta.comcast.com/firebolt/types#/definitions/SemanticVersion",
-              "description": "The semantic version of the FEE."
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/components/schemas/InitializeResult"
         }
       },
       "examples": [
@@ -76,7 +68,19 @@
     }
   ],
   "components": {
-    "schemas": {    
+    "schemas": {
+      "InitializeResult": {
+        "title": "InitializeResult",
+        "type": "object",
+        "required": ["version"],
+        "properties": {
+          "version": {
+            "$ref": "https://meta.comcast.com/firebolt/types#/definitions/SemanticVersion",
+            "description": "The semantic version of the FEE."
+          }
+        },
+        "additionalProperties": false
+      }
     }
   }
 }

--- a/src/openrpc/advertising.json
+++ b/src/openrpc/advertising.json
@@ -81,8 +81,7 @@
         {
           "name": "capabilities",
           "x-uses": [
-            "xrn:firebolt:capability:privacy:advertising",
-            "xrn:firebolt:capability:advertising:configuration"
+            "xrn:firebolt:capability:advertising:policy"
           ]
         }
       ],
@@ -157,7 +156,7 @@
           ]
         }
       ],
-      "summary": "Get the advertising ID",
+      "summary": "Get the IAB compliant identifier for advertising (IFA). It is recommended to use the IFA to manage advertising related activities while respecting the user's privacy settings.",
       "params": [
         {
           "name": "options",
@@ -172,21 +171,7 @@
         "name": "advertisingId",
         "summary": "the advertising ID",
         "schema": {
-          "type": "object",
-          "properties": {
-            "ifa": {
-              "type": "string"
-            },
-            "ifa_type": {
-              "type": "string"
-            },
-            "lmt": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "ifa"
-          ]
+          "$ref": "#/components/schemas/AdvertisingIdResult"
         }
       },
       "examples": [
@@ -303,7 +288,7 @@
           "params": [],
           "result": {
             "name": "Default Result",
-            "value": "operator.app"
+            "value": "app.operator"
           }
         }
       ]
@@ -404,6 +389,27 @@
             }
           }
         }
+      },
+      "AdvertisingIdResult": {
+        "title": "AdvertisingIdResult",
+        "type": "object",
+        "properties": {
+          "ifa": {
+            "type": "string",
+            "description": "UUID conforming to IAB standard"
+          },
+          "ifa_type": {
+            "type": "string",
+            "description": "source of the IFA as defined by IAB"
+          },
+          "lmt": {
+            "type": "string",
+            "description": "boolean that if set to 1, user has requested ad tracking and measurement is disabled"
+          }
+        },
+        "required": [
+          "ifa"
+        ]
       }
     }
   }

--- a/src/openrpc/advertising.json
+++ b/src/openrpc/advertising.json
@@ -182,7 +182,7 @@
             "name": "Default Result",
             "value": {
               "ifa": "01234567-89AB-CDEF-GH01-23456789ABCD",
-              "ifa_type": "idfa",
+              "ifa_type": "sspid",
               "lmt": "0"
             }
           }
@@ -204,7 +204,7 @@
             "name": "Default Result",
             "value": {
               "ifa": "01234567-89AB-CDEF-GH01-23456789ABCD",
-              "ifa_type": "idfa",
+              "ifa_type": "sspid",
               "lmt": "0"
             }
           }

--- a/src/openrpc/advertising.json
+++ b/src/openrpc/advertising.json
@@ -404,11 +404,17 @@
           },
           "lmt": {
             "type": "string",
+            "enum": [
+              "0",
+              "1"
+            ],
             "description": "boolean that if set to 1, user has requested ad tracking and measurement is disabled"
           }
         },
         "required": [
-          "ifa"
+          "ifa",
+          "ifa_type",
+          "lmt"
         ]
       }
     }

--- a/src/openrpc/authentication.json
+++ b/src/openrpc/authentication.json
@@ -44,22 +44,7 @@
         "name": "token",
         "summary": "the token value, type, and expiration",
         "schema": {
-          "type": "object",
-          "properties": {
-            "value": {
-              "type": "string"
-            },
-            "expires": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "type": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "value"
-          ]
+          "$ref": "#/components/schemas/AuthenticationTokenResult"
         }
       },
       "examples": [
@@ -232,6 +217,25 @@
           "platform",
           "device",
           "distributor"
+        ]
+      },
+      "AuthenticationTokenResult": {
+        "title": "AuthenticationTokenResult",
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "expires": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "value"
         ]
       }
     }

--- a/src/openrpc/device.json
+++ b/src/openrpc/device.json
@@ -351,7 +351,7 @@
         "name": "supportedHdcpProfiles",
         "summary": "the supported HDCP profiles",
         "schema": {
-          "$ref": "#/components/schemas/HDCPType"
+          "$ref": "#/components/schemas/HDCPVersion"
         }
       },
       "examples": [
@@ -387,7 +387,7 @@
         "name": "supportedHdrProfiles",
         "summary": "the supported HDR profiles",
         "schema": {
-          "$ref": "#/components/schemas/HDRType"
+          "$ref": "#/components/schemas/HDRFormat"
         }
       },
       "examples": [
@@ -834,6 +834,7 @@
       },
       "AudioProfiles": {
         "title": "AudioProfiles",
+        "type": "object",
         "properties": {
           "stereo": {
             "type": "boolean"
@@ -847,10 +848,16 @@
           "dolbyAtmos": {
             "type": "boolean"
           }
-        }
+        },
+        "required": [
+          "stereo",
+          "dolbyDigital5.1",
+          "dolbyDigital5.1+",
+          "dolbyAtmos"
+        ]
       },
-      "HDRType": {
-        "title": "HDRType",
+      "HDRFormat": {
+        "title": "HDRFormat",
         "type": "object",
         "properties": {
           "hdr10": {
@@ -874,8 +881,8 @@
         ],
         "description": "The type of HDR that is supported"
       },
-      "HDCPType": {
-        "title": "HDCPType",
+      "HDCPVersion": {
+        "title": "HDCPVersion",
         "type": "object",
         "properties": {
           "hdcp1.4": {
@@ -901,7 +908,7 @@
           },
           "api": {
             "$ref": "https://meta.comcast.com/firebolt/types#/definitions/SemanticVersion",
-            "description": "The lateset Firebolt API version supported by the curent device."
+            "description": "The latest Firebolt API version supported by the current device."
           },
           "firmware": {
             "$ref": "https://meta.comcast.com/firebolt/types#/definitions/SemanticVersion",

--- a/src/openrpc/device.json
+++ b/src/openrpc/device.json
@@ -351,7 +351,7 @@
         "name": "supportedHdcpVersions",
         "summary": "the supported HDCP versions",
         "schema": {
-          "$ref": "#/components/schemas/HDCPVersion"
+          "$ref": "#/components/schemas/HDCPVersionMap"
         }
       },
       "examples": [
@@ -387,7 +387,7 @@
         "name": "supportedHdrFormats",
         "summary": "the supported HDR formats",
         "schema": {
-          "$ref": "#/components/schemas/HDRFormat"
+          "$ref": "#/components/schemas/HDRFormatMap"
         }
       },
       "examples": [
@@ -856,8 +856,8 @@
           "dolbyAtmos"
         ]
       },
-      "HDRFormat": {
-        "title": "HDRFormat",
+      "HDRFormatMap": {
+        "title": "HDRFormatMap",
         "type": "object",
         "properties": {
           "hdr10": {
@@ -881,8 +881,8 @@
         ],
         "description": "The type of HDR that is supported"
       },
-      "HDCPVersion": {
-        "title": "HDCPVersion",
+      "HDCPVersionMap": {
+        "title": "HDCPVersionMap",
         "type": "object",
         "properties": {
           "hdcp1.4": {

--- a/src/openrpc/device.json
+++ b/src/openrpc/device.json
@@ -348,15 +348,15 @@
         }
       ],
       "result": {
-        "name": "supportedHdcpProfiles",
-        "summary": "the supported HDCP profiles",
+        "name": "supportedHdcpVersions",
+        "summary": "the supported HDCP versions",
         "schema": {
           "$ref": "#/components/schemas/HDCPVersion"
         }
       },
       "examples": [
         {
-          "name": "Getting the supported HDCP profiles",
+          "name": "Getting the supported HDCP versions",
           "params": [],
           "result": {
             "name": "Default Result",
@@ -384,15 +384,15 @@
         }
       ],
       "result": {
-        "name": "supportedHdrProfiles",
-        "summary": "the supported HDR profiles",
+        "name": "supportedHdrFormats",
+        "summary": "the supported HDR formats",
         "schema": {
           "$ref": "#/components/schemas/HDRFormat"
         }
       },
       "examples": [
         {
-          "name": "Getting the supported HDR profiles",
+          "name": "Getting the supported HDR formats",
           "params": [],
           "result": {
             "name": "Default Result",
@@ -446,7 +446,7 @@
     },
     {
       "name": "screenResolution",
-      "summary": "Get the maximum supported screen resolution for the graphical surface of the app. \n\nThe pairs returned will be of a [width, height] format and will correspond to the following values: \n\nNTSC Standard Definition (SD): [720, 480] \n\nPAL Standard Definition (SD): [720, 576] \n\nHigh Definition (HD): [1280, 720] \n\nFull HD (FHD): [1920, 1080]\n\n4K Ultra High Definition (UHD): [1920, 1080]",
+      "summary": "Get the resolution for the graphical surface of the app. \n\nThe pairs returned will be of a [width, height] format and will correspond to the following values: \n\nNTSC Standard Definition (SD): [720, 480] \n\nPAL Standard Definition (SD): [720, 576] \n\nHigh Definition (HD): [1280, 720] \n\nFull HD (FHD): [1920, 1080]\n\n4K Ultra High Definition (UHD): [3840, 2160]",
       "params": [],
       "tags": [
         {
@@ -482,7 +482,7 @@
     },
     {
       "name": "videoResolution",
-      "summary": "Get the maximum supported video resolution of the currently connected device and display. \n\nThe pairs returned will be of a [width, height] format and will correspond to the following values: \n\nNTSC Standard Definition (SD): [720, 480] \n\nPAL Standard Definition (SD): [720, 576] \n\nHigh Definition (HD): [1280, 720] \n\nFull HD (FHD): [1920, 1080]\n\n4K Ultra High Definition (UHD): [1920, 1080]",
+      "summary": "Get the maximum supported video resolution of the currently connected device and display. \n\nThe pairs returned will be of a [width, height] format and will correspond to the following values: \n\nNTSC Standard Definition (SD): [720, 480] \n\nPAL Standard Definition (SD): [720, 576] \n\nHigh Definition (HD): [1280, 720] \n\nFull HD (FHD): [1920, 1080]\n\n4K Ultra High Definition (UHD): [3840, 2160]",
       "params": [],
       "tags": [
         {

--- a/src/openrpc/device.json
+++ b/src/openrpc/device.json
@@ -292,34 +292,7 @@
         "name": "versions",
         "summary": "the versions",
         "schema": {
-          "type": "object",
-          "properties": {
-            "sdk": {
-              "$ref": "https://meta.comcast.com/firebolt/types#/definitions/SemanticVersion",
-              "description": "The Firebolt SDK version"
-            },
-            "api": {
-              "$ref": "https://meta.comcast.com/firebolt/types#/definitions/SemanticVersion",
-              "description": "The lateset Firebolt API version supported by the curent device."
-            },
-            "firmware": {
-              "$ref": "https://meta.comcast.com/firebolt/types#/definitions/SemanticVersion",
-              "description": "The device firmware version."
-            },
-            "os": {
-              "$ref": "https://meta.comcast.com/firebolt/types#/definitions/SemanticVersion",
-              "description": "**Deprecated** Use `firmware`, instead."
-            },
-            "debug": {
-              "type": "string",
-              "description": "Detail version as a string, for debugging purposes"
-            }
-          },
-          "required": [
-            "api",
-            "firmware",
-            "os"
-          ]
+          "$ref": "#/components/schemas/HDCPType"
         }
       },
       "examples": [
@@ -378,7 +351,7 @@
         "name": "supportedHdcpProfiles",
         "summary": "the supported HDCP profiles",
         "schema": {
-          "$ref": "https://meta.comcast.com/firebolt/types#/definitions/BooleanMap"
+          "$ref": "#/components/schemas/HDCPType"
         }
       },
       "examples": [
@@ -414,7 +387,7 @@
         "name": "supportedHdrProfiles",
         "summary": "the supported HDR profiles",
         "schema": {
-          "$ref": "https://meta.comcast.com/firebolt/types#/definitions/BooleanMap"
+          "$ref": "#/components/schemas/HDRType"
         }
       },
       "examples": [
@@ -435,7 +408,7 @@
     },
     {
       "name": "audio",
-      "summary": "Get the supported audio profiles",
+      "summary": "Get the supported audio profiles for the connected devices. \n\n It is not recommended to use this API for visual badging on content within your app since this does not reflect the settings of the user. \n\n  **Note:** This method is planned to be deprecated with a future Firebolt release",
       "params": [],
       "tags": [
         {
@@ -473,7 +446,7 @@
     },
     {
       "name": "screenResolution",
-      "summary": "Get the current screen resolution",
+      "summary": "Get the maximum supported video resolution for the graphical surface of the app. \n\nThe pairs returned will be of a [width, height] format and will correspond to the following values: \n\nNTSC Standard Definition (SD): [720, 480] \n\nPAL Standard Definition (SD): [720, 576] \n\nHigh Definition (HD): [1280, 720] \n\nFull HD (FHD): [1920, 1080]\n\n4K Ultra High Definition (UHD): [1920, 1080] \n\n**Note:** This method will be deprecated with a future Firebolt release",
       "params": [],
       "tags": [
         {
@@ -509,7 +482,7 @@
     },
     {
       "name": "videoResolution",
-      "summary": "Get the current video resolution",
+      "summary": "Get the maximum supported video resolution of the currently connected device and display. \n\nThe pairs returned will be of a [width, height] format and will correspond to the following values: \n\nNTSC Standard Definition (SD): [720, 480] \n\nPAL Standard Definition (SD): [720, 576] \n\nHigh Definition (HD): [1280, 720] \n\nFull HD (FHD): [1920, 1080]\n\n4K Ultra High Definition (UHD): [1920, 1080] \n\n**Note:** This method will be deprecated with a future Firebolt release",
       "params": [],
       "tags": [
         {
@@ -641,19 +614,7 @@
         "name": "networkInfo",
         "summary": "the status and type",
         "schema": {
-          "type": "object",
-          "properties": {
-            "state": {
-              "$ref": "#/components/schemas/NetworkState"
-            },
-            "type": {
-              "$ref": "#/components/schemas/NetworkType"
-            }
-          },
-          "required": [
-            "state",
-            "type"
-          ]
+          "$ref": "#/components/schemas/NetworkInfoResult"
         }
       },
       "examples": [
@@ -759,18 +720,98 @@
   "components": {
     "schemas": {
       "Resolution": {
-        "type": "array",
-        "items": [
+        "oneOf": [
           {
-            "type": "integer"
+            "type": "array",
+            "items": [
+              {
+                "type": "integer",
+                "const": 720,
+                "description": "Width in pixels"
+              },
+              {
+                "type": "integer",
+                "const": 480,
+                "description": "Height in pixels"
+              }
+            ],
+            "additionalItems": false,
+            "minItems": 2,
+            "maxItems": 2
           },
           {
-            "type": "integer"
+            "type": "array",
+            "items": [
+              {
+                "type": "integer",
+                "const": 720,
+                "description": "Width in pixels"
+              },
+              {
+                "type": "integer",
+                "const": 576,
+                "description": "Height in pixels"
+              }
+            ],
+            "additionalItems": false,
+            "minItems": 2,
+            "maxItems": 2
+          },
+          {
+            "type": "array",
+            "items": [
+              {
+                "type": "integer",
+                "const": 1280,
+                "description": "Width in pixels"
+              },
+              {
+                "type": "integer",
+                "const": 720,
+                "description": "Height in pixels"
+              }
+            ],
+            "additionalItems": false,
+            "minItems": 2,
+            "maxItems": 2
+          },
+          {
+            "type": "array",
+            "items": [
+              {
+                "type": "integer",
+                "const": 1920,
+                "description": "Width in pixels"
+              },
+              {
+                "type": "integer",
+                "const": 1080,
+                "description": "Height in pixels"
+              }
+            ],
+            "additionalItems": false,
+            "minItems": 2,
+            "maxItems": 2
+          },
+          {
+            "type": "array",
+            "items": [
+              {
+                "type": "integer",
+                "const": 3840,
+                "description": "Width in pixels"
+              },
+              {
+                "type": "integer",
+                "const": 2160,
+                "description": "Height in pixels"
+              }
+            ],
+            "additionalItems": false,
+            "minItems": 2,
+            "maxItems": 2
           }
-        ],
-        "additionalItems": false,
-        "minItems": 2,
-        "maxItems": 2
+        ]
       },
       "NetworkType": {
         "title": "NetworkType",
@@ -793,16 +834,98 @@
       },
       "AudioProfiles": {
         "title": "AudioProfiles",
-        "allOf": [
-          {
-            "$ref": "https://meta.comcast.com/firebolt/types#/definitions/BooleanMap"
+        "properties": {
+          "stereo": {
+            "type": "boolean"
           },
-          {
-            "type": "object",
-            "propertyNames": {
-              "$ref": "https://meta.comcast.com/firebolt/types#/definitions/AudioProfile"
-            }
+          "dolbyDigital5.1": {
+            "type": "boolean"
+          },
+          "dolbyDigital5.1+": {
+            "type": "boolean"
+          },
+          "dolbyAtmos": {
+            "type": "boolean"
           }
+        }
+      },
+      "HDRType": {
+        "title": "HDRType",
+        "type": "object",
+        "properties": {
+          "hdr10": {
+            "type": "boolean"
+          },
+          "hdr10plus": {
+            "type": "boolean"
+          },
+          "dolbyVision": {
+            "type": "boolean"
+          },
+          "hlg": {
+            "type": "boolean"
+          }
+        },
+        "description": "The type of HDR that is supported"
+      },
+      "HDCPType": {
+        "title": "HDCPType",
+        "type": "object",
+        "properties": {
+          "hdcp1.4": {
+            "type": "boolean"
+          },
+          "hdcp2.2": {
+            "type": "boolean"
+          }
+        },
+        "description": "The type of HDCP that is supported"
+      },
+      "DeviceVersion": {
+        "title": "DeviceVersion",
+        "type": "object",
+        "properties": {
+          "sdk": {
+            "$ref": "https://meta.comcast.com/firebolt/types#/definitions/SemanticVersion",
+            "description": "The Firebolt SDK version"
+          },
+          "api": {
+            "$ref": "https://meta.comcast.com/firebolt/types#/definitions/SemanticVersion",
+            "description": "The lateset Firebolt API version supported by the curent device."
+          },
+          "firmware": {
+            "$ref": "https://meta.comcast.com/firebolt/types#/definitions/SemanticVersion",
+            "description": "The device firmware version."
+          },
+          "os": {
+            "$ref": "https://meta.comcast.com/firebolt/types#/definitions/SemanticVersion",
+            "description": "**Deprecated** Use `firmware`, instead."
+          },
+          "debug": {
+            "type": "string",
+            "description": "Detail version as a string, for debugging purposes"
+          }
+        },
+        "required": [
+          "api",
+          "firmware",
+          "os"
+        ]
+      },
+      "NetworkInfoResult": {
+        "title": "NetworkInfoResult",
+        "type": "object",
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/NetworkState"
+          },
+          "type": {
+            "$ref": "#/components/schemas/NetworkType"
+          }
+        },
+        "required": [
+          "state",
+          "type"
         ]
       }
     }

--- a/src/openrpc/device.json
+++ b/src/openrpc/device.json
@@ -879,7 +879,7 @@
           "dolbyVision",
           "hlg"
         ],
-        "description": "The type of HDR that is supported"
+        "description": "The type of HDR format that is supported"
       },
       "HDCPVersionMap": {
         "title": "HDCPVersionMap",
@@ -896,7 +896,7 @@
           "hdcp1.4",
           "hdcp2.2"
         ],
-        "description": "The type of HDCP that is supported"
+        "description": "The type of HDCP versions that is supported"
       },
       "DeviceVersion": {
         "title": "DeviceVersion",

--- a/src/openrpc/device.json
+++ b/src/openrpc/device.json
@@ -334,7 +334,7 @@
     },
     {
       "name": "hdcp",
-      "summary": "Get the supported HDCP profiles",
+      "summary": "Get the negotiated HDCP profiles for a connected device. \n\n For devices that do not require additional connections (e.g. panels), `true` will be returned for all profiles.",
       "params": [],
       "tags": [
         {
@@ -370,7 +370,7 @@
     },
     {
       "name": "hdr",
-      "summary": "Get the supported HDR profiles",
+      "summary": "Get the negotiated HDR formats for the connected display and device",
       "params": [],
       "tags": [
         {
@@ -912,7 +912,7 @@
           },
           "firmware": {
             "$ref": "https://meta.comcast.com/firebolt/types#/definitions/SemanticVersion",
-            "description": "The device firmware version."
+            "description": "The firmware version as reported by the device"
           },
           "os": {
             "$ref": "https://meta.comcast.com/firebolt/types#/definitions/SemanticVersion",
@@ -920,7 +920,7 @@
           },
           "debug": {
             "type": "string",
-            "description": "Detail version as a string, for debugging purposes"
+            "description": "Detailed version as a string, for debugging purposes"
           }
         },
         "required": [

--- a/src/openrpc/device.json
+++ b/src/openrpc/device.json
@@ -408,7 +408,7 @@
     },
     {
       "name": "audio",
-      "summary": "Get the supported audio profiles for the connected devices. \n\n It is not recommended to use this API for visual badging on content within your app since this does not reflect the settings of the user. \n\n  **Note:** This method is planned to be deprecated with a future Firebolt release",
+      "summary": "Get the supported audio profiles for the connected devices. \n\n It is not recommended to use this API for visual badging on content within your app since this does not reflect the settings of the user.",
       "params": [],
       "tags": [
         {
@@ -446,7 +446,7 @@
     },
     {
       "name": "screenResolution",
-      "summary": "Get the maximum supported screen resolution for the graphical surface of the app. \n\nThe pairs returned will be of a [width, height] format and will correspond to the following values: \n\nNTSC Standard Definition (SD): [720, 480] \n\nPAL Standard Definition (SD): [720, 576] \n\nHigh Definition (HD): [1280, 720] \n\nFull HD (FHD): [1920, 1080]\n\n4K Ultra High Definition (UHD): [1920, 1080] \n\n**Note:** This method will be deprecated with a future Firebolt release",
+      "summary": "Get the maximum supported screen resolution for the graphical surface of the app. \n\nThe pairs returned will be of a [width, height] format and will correspond to the following values: \n\nNTSC Standard Definition (SD): [720, 480] \n\nPAL Standard Definition (SD): [720, 576] \n\nHigh Definition (HD): [1280, 720] \n\nFull HD (FHD): [1920, 1080]\n\n4K Ultra High Definition (UHD): [1920, 1080]",
       "params": [],
       "tags": [
         {
@@ -482,7 +482,7 @@
     },
     {
       "name": "videoResolution",
-      "summary": "Get the maximum supported video resolution of the currently connected device and display. \n\nThe pairs returned will be of a [width, height] format and will correspond to the following values: \n\nNTSC Standard Definition (SD): [720, 480] \n\nPAL Standard Definition (SD): [720, 576] \n\nHigh Definition (HD): [1280, 720] \n\nFull HD (FHD): [1920, 1080]\n\n4K Ultra High Definition (UHD): [1920, 1080] \n\n**Note:** This method will be deprecated with a future Firebolt release",
+      "summary": "Get the maximum supported video resolution of the currently connected device and display. \n\nThe pairs returned will be of a [width, height] format and will correspond to the following values: \n\nNTSC Standard Definition (SD): [720, 480] \n\nPAL Standard Definition (SD): [720, 576] \n\nHigh Definition (HD): [1280, 720] \n\nFull HD (FHD): [1920, 1080]\n\n4K Ultra High Definition (UHD): [1920, 1080]",
       "params": [],
       "tags": [
         {

--- a/src/openrpc/device.json
+++ b/src/openrpc/device.json
@@ -292,7 +292,7 @@
         "name": "versions",
         "summary": "the versions",
         "schema": {
-          "$ref": "#/components/schemas/HDCPType"
+          "$ref": "#/components/schemas/DeviceVersion"
         }
       },
       "examples": [
@@ -446,7 +446,7 @@
     },
     {
       "name": "screenResolution",
-      "summary": "Get the maximum supported video resolution for the graphical surface of the app. \n\nThe pairs returned will be of a [width, height] format and will correspond to the following values: \n\nNTSC Standard Definition (SD): [720, 480] \n\nPAL Standard Definition (SD): [720, 576] \n\nHigh Definition (HD): [1280, 720] \n\nFull HD (FHD): [1920, 1080]\n\n4K Ultra High Definition (UHD): [1920, 1080] \n\n**Note:** This method will be deprecated with a future Firebolt release",
+      "summary": "Get the maximum supported screen resolution for the graphical surface of the app. \n\nThe pairs returned will be of a [width, height] format and will correspond to the following values: \n\nNTSC Standard Definition (SD): [720, 480] \n\nPAL Standard Definition (SD): [720, 576] \n\nHigh Definition (HD): [1280, 720] \n\nFull HD (FHD): [1920, 1080]\n\n4K Ultra High Definition (UHD): [1920, 1080] \n\n**Note:** This method will be deprecated with a future Firebolt release",
       "params": [],
       "tags": [
         {
@@ -856,7 +856,7 @@
           "hdr10": {
             "type": "boolean"
           },
-          "hdr10plus": {
+          "hdr10Plus": {
             "type": "boolean"
           },
           "dolbyVision": {
@@ -866,6 +866,12 @@
             "type": "boolean"
           }
         },
+        "required": [
+          "hdr10",
+          "hdr10Plus",
+          "dolbyVision",
+          "hlg"
+        ],
         "description": "The type of HDR that is supported"
       },
       "HDCPType": {
@@ -879,6 +885,10 @@
             "type": "boolean"
           }
         },
+        "required": [
+          "hdcp1.4",
+          "hdcp2.2"
+        ],
         "description": "The type of HDCP that is supported"
       },
       "DeviceVersion": {

--- a/src/schemas/accessibility.json
+++ b/src/schemas/accessibility.json
@@ -100,8 +100,7 @@
             "title": "ClosedCaptionsSettings",
             "type": "object",
             "required": [
-                "enabled",
-                "styles"
+                "enabled"
             ],
             "properties": {
                 "enabled": {
@@ -152,8 +151,7 @@
             "title": "VoiceGuidanceSettings",
             "type": "object",
             "required": [
-                "enabled",
-                "speed"
+                "enabled"
             ],
             "properties": {
                 "enabled": {

--- a/src/schemas/types.json
+++ b/src/schemas/types.json
@@ -36,9 +36,7 @@
             "enum": [
                 "stereo",
                 "dolbyDigital5.1",
-                "dolbyDigital7.1",
                 "dolbyDigital5.1+",
-                "dolbyDigital7.1+",
                 "dolbyAtmos"
             ]
         },

--- a/src/sdks/core/sdk.config.json
+++ b/src/sdks/core/sdk.config.json
@@ -23,7 +23,7 @@
             "use": [
                 "xrn:firebolt:capability:advertising:configuration",
                 "xrn:firebolt:capability:advertising:identifier",
-                "xrn:firebolt:capability:privacy:advertising"
+                "xrn:firebolt:capability:advertising:policy"
             ]
         },
         {

--- a/src/sdks/core/test/suite/advertising.test.ts
+++ b/src/sdks/core/test/suite/advertising.test.ts
@@ -50,7 +50,7 @@ test("deviceAttributes()", () => {
 
 test("appBundleId()", () => {
   return Advertising.appBundleId().then((res: string) => {
-    expect(res).toBe("operator.app");
+    expect(res).toBe("app.operator");
     expect(typeof res).toBe("string");
   });
 });


### PR DESCRIPTION
This PR contains below fixes:

1. Create enum values in BooleanMap for device.hdr Response
2. Create enum values in BooleanMap for device.hdcp Response
3. Create enum values in BooleanMap for device.audio Response
4. Update device.videoResolution description and result
5. Update Device.screenResolution description and result
6. Update Accessibility.closedCaptionsSettings and Accessibility.closedCaptions key options
7. Update Accessibility.voiceGuidance and Accessibility.voiceGuidanceSettings key options
8. Update Advertising.appBundleId example
9. Update Advertising.advertisingId to define attributes and updated description
10. Update Advertising.policy capability to singular capability
11. Update description for Device.version