### PR TITLE
feat: Add global subscribe & HDMI tests to manage test app

### DIFF
--- a/src/sdks/manage/src/cpp/sdk/cpptest/Main.cpp
+++ b/src/sdks/manage/src/cpp/sdk/cpptest/Main.cpp
@@ -121,6 +121,9 @@ void RunAllTests() {
         runTest(ManageSDKTest::SendResponseMessageToPinChallengeProvider, "SendResponseMessageToPinChallengeProvider");
         runTest(ManageSDKTest::SendErrorMessageToPinChallengeProvider, "SendErrorMessageToPinChallengeProvider");
 
+        runTest(ManageSDKTest::GlobalSubscribeHdmiAutoLowLatencyModeCapableChanged, "GlobalSubscribeHdmiAutoLowLatencyModeCapableChanged");
+        runTest(ManageSDKTest::GlobalUnsubscribeHdmiAutoLowLatencyModeCapableChanged, "GlobalUnsubscribeHdmiAutoLowLatencyModeCapableChanged");
+
         if (allTestsPassed) {
             cout << "============================" << endl;
             cout << "ALL MANAGE SDK TESTS SUCCEEDED!" << endl;

--- a/src/sdks/manage/src/cpp/sdk/cpptest/Main.cpp
+++ b/src/sdks/manage/src/cpp/sdk/cpptest/Main.cpp
@@ -124,6 +124,12 @@ void RunAllTests() {
         runTest(ManageSDKTest::GlobalSubscribeHdmiAutoLowLatencyModeCapableChanged, "GlobalSubscribeHdmiAutoLowLatencyModeCapableChanged");
         runTest(ManageSDKTest::GlobalUnsubscribeHdmiAutoLowLatencyModeCapableChanged, "GlobalUnsubscribeHdmiAutoLowLatencyModeCapableChanged");
 
+        runTest(ManageSDKTest::GetAutoLowLatencyModeCapable, "GetAutoLowLatencyModeCapable");
+        runTest(ManageSDKTest::SetAutoLowLatencyModeCapable, "SetAutoLowLatencyModeCapable");
+        runTest(ManageSDKTest::GetEdidVersion, "GetEdidVersion");
+        runTest(ManageSDKTest::SetEdidVersion, "SetEdidVersion");
+        runTest(ManageSDKTest::GetHdmiPortInfo, "GetHdmiPortInfo");
+        
         if (allTestsPassed) {
             cout << "============================" << endl;
             cout << "ALL MANAGE SDK TESTS SUCCEEDED!" << endl;

--- a/src/sdks/manage/src/cpp/sdk/cpptest/ManageSDKTest.cpp
+++ b/src/sdks/manage/src/cpp/sdk/cpptest/ManageSDKTest.cpp
@@ -31,6 +31,7 @@ ManageSDKTest::OnPreferredAudioLanguagesChangedNotification ManageSDKTest::_pref
 ManageSDKTest::OnAllowACRCollectionChangedNotification ManageSDKTest::_allowACRCollectionChangedNotification;
 ManageSDKTest::OnSignInNotification ManageSDKTest::_signInNotification;
 ManageSDKTest::OnSignOutNotification ManageSDKTest::_signOutNotification;
+ManageSDKTest::OnAutoLowLatencyModeCapableChangedNotification ManageSDKTest::_autoLowLatencyModeCapableChangedNotification;
 ManageSDKTest::KeyboardProvider ManageSDKTest::_keyboardProvider;
 ManageSDKTest::AcknowledgeChallengeProvider ManageSDKTest::_acknowledgeChallengeProvider;
 ManageSDKTest::PinChallengeProvider ManageSDKTest::_pinChallengeProvider;
@@ -1010,5 +1011,34 @@ void ManageSDKTest::WifiDisconnect()
     } else {
         std::string errorMessage = "Error: " + std::to_string(static_cast<int>(error));
         throw std::runtime_error("WifiDisconnect failed. " + errorMessage);
+    }
+}
+
+void ManageSDKTest::OnAutoLowLatencyModeCapableChangedNotification::onAutoLowLatencyModeCapableChanged( const Firebolt::HDMIInput::AutoLowLatencyModeCapableChangedInfo& info)
+{
+    cout << "Low latency capable changed"  << endl;
+}
+
+void ManageSDKTest::GlobalSubscribeHdmiAutoLowLatencyModeCapableChanged()
+{
+    Firebolt::Error error = Firebolt::Error::None;
+    Firebolt::IFireboltAccessor::Instance().HDMIInputInterface().globalSubscribe(_autoLowLatencyModeCapableChangedNotification, &error);
+    if (error == Firebolt::Error::None) {
+        cout << "Subscribe HDMIInput AutoLowLatencyModeCapable is success" << endl;
+    } else {
+        std::string errorMessage = "Error: " + std::to_string(static_cast<int>(error));
+        throw std::runtime_error("SubscribeHDMIInputAutoLowLatencyModeCapable failed. " + errorMessage);
+    }
+}
+
+void ManageSDKTest::GlobalUnsubscribeHdmiAutoLowLatencyModeCapableChanged()
+{
+    Firebolt::Error error = Firebolt::Error::None;
+    Firebolt::IFireboltAccessor::Instance().HDMIInputInterface().globalUnsubscribe(_autoLowLatencyModeCapableChangedNotification, &error);
+    if (error == Firebolt::Error::None) {
+        cout << "Unsubscribe HDMIInput AutoLowLatencyModeCapable is success" << endl;
+    } else {
+        std::string errorMessage = "Error: " + std::to_string(static_cast<int>(error));
+        throw std::runtime_error("UnsubscribeHDMIInputAutoLowLatencyModeCapable failed. " + errorMessage);
     }
 }

--- a/src/sdks/manage/src/cpp/sdk/cpptest/ManageSDKTest.cpp
+++ b/src/sdks/manage/src/cpp/sdk/cpptest/ManageSDKTest.cpp
@@ -1024,10 +1024,10 @@ void ManageSDKTest::GlobalSubscribeHdmiAutoLowLatencyModeCapableChanged()
     Firebolt::Error error = Firebolt::Error::None;
     Firebolt::IFireboltAccessor::Instance().HDMIInputInterface().globalSubscribe(_autoLowLatencyModeCapableChangedNotification, &error);
     if (error == Firebolt::Error::None) {
-        cout << "Subscribe HDMIInput AutoLowLatencyModeCapable is success" << endl;
+        cout << "Global Subscribe for HDMIInput AutoLowLatencyModeCapable is a success." << endl;
     } else {
         std::string errorMessage = "Error: " + std::to_string(static_cast<int>(error));
-        throw std::runtime_error("SubscribeHDMIInputAutoLowLatencyModeCapable failed. " + errorMessage);
+        throw std::runtime_error("SubscribeHDMIInputAutoLowLatencyModeCapable failed." + errorMessage);
     }
 }
 
@@ -1036,9 +1036,81 @@ void ManageSDKTest::GlobalUnsubscribeHdmiAutoLowLatencyModeCapableChanged()
     Firebolt::Error error = Firebolt::Error::None;
     Firebolt::IFireboltAccessor::Instance().HDMIInputInterface().globalUnsubscribe(_autoLowLatencyModeCapableChangedNotification, &error);
     if (error == Firebolt::Error::None) {
-        cout << "Unsubscribe HDMIInput AutoLowLatencyModeCapable is success" << endl;
+        cout << "Global Unsubscribe for HDMIInput AutoLowLatencyModeCapable is a success." << endl;
     } else {
         std::string errorMessage = "Error: " + std::to_string(static_cast<int>(error));
-        throw std::runtime_error("UnsubscribeHDMIInputAutoLowLatencyModeCapable failed. " + errorMessage);
+        throw std::runtime_error("UnsubscribeHDMIInputAutoLowLatencyModeCapable failed." + errorMessage);
+    }
+}
+
+void ManageSDKTest::GetAutoLowLatencyModeCapable()
+{
+    Firebolt::Error error = Firebolt::Error::None;
+    std::string port = "HDMI1";
+    bool result = Firebolt::IFireboltAccessor::Instance().HDMIInputInterface().autoLowLatencyModeCapable(port, &error);
+
+    if (error == Firebolt::Error::None) {
+        cout << "GetAutoLowLatencyModeCapable is a success." << endl;
+    } else {
+        std::string errorMessage = "Error: " + std::to_string(static_cast<int>(error));
+        throw std::runtime_error("GetAutoLowLatencyModeCapable failed. " + errorMessage);
+    }
+}
+
+void ManageSDKTest::SetAutoLowLatencyModeCapable()
+{
+    Firebolt::Error error = Firebolt::Error::None;
+    std::string port = "HDMI1";
+    bool value = false;
+    Firebolt::IFireboltAccessor::Instance().HDMIInputInterface().setAutoLowLatencyModeCapable(port, value, &error);
+
+    if (error == Firebolt::Error::None) {
+        cout << "SetAutoLowLatencyModeCapable is a success." << endl;
+    } else {
+        std::string errorMessage = "Error: " + std::to_string(static_cast<int>(error));
+        throw std::runtime_error("SetAutoLowLatencyModeCapable failed. " + errorMessage);
+    }
+}
+
+void ManageSDKTest::GetEdidVersion()
+{
+    Firebolt::Error error = Firebolt::Error::None;
+    std::string port = "HDMI1";
+    Firebolt::IFireboltAccessor::Instance().HDMIInputInterface().edidVersion(port, &error);
+
+    if (error == Firebolt::Error::None) {
+        cout << "GetEdidVersion is a success." << endl;
+    } else {
+        std::string errorMessage = "Error: " + std::to_string(static_cast<int>(error));
+        throw std::runtime_error("GetEdidVersion failed. " + errorMessage);
+    }
+}
+
+void ManageSDKTest::SetEdidVersion()
+{
+    Firebolt::Error error = Firebolt::Error::None;
+    std::string port = "HDMI1";
+    Firebolt::HDMIInput::EDIDVersion value = Firebolt::HDMIInput::EDIDVersion::V1_4;
+    Firebolt::IFireboltAccessor::Instance().HDMIInputInterface().setEdidVersion(port, value, &error);
+
+    if (error == Firebolt::Error::None) {
+        cout << "SetEdidVersion is a success." << endl;
+    } else {
+        std::string errorMessage = "Error: " + std::to_string(static_cast<int>(error));
+        throw std::runtime_error("SetEdidVersionfailed. " + errorMessage);
+    }
+}
+
+void ManageSDKTest::GetHdmiPortInfo()
+{
+    Firebolt::Error error = Firebolt::Error::None;
+    std::string portId = "HDMI1";
+    Firebolt::IFireboltAccessor::Instance().HDMIInputInterface().port(portId, &error);
+
+    if (error == Firebolt::Error::None) {
+        cout << "GetHdmiPortInfo is a success." << endl;
+    } else {
+        std::string errorMessage = "Error: " + std::to_string(static_cast<int>(error));
+        throw std::runtime_error("GetHdmiPortInfo failed. " + errorMessage);
     }
 }

--- a/src/sdks/manage/src/cpp/sdk/cpptest/ManageSDKTest.h
+++ b/src/sdks/manage/src/cpp/sdk/cpptest/ManageSDKTest.h
@@ -191,6 +191,12 @@ public:
     static void GlobalSubscribeHdmiAutoLowLatencyModeCapableChanged();
     static void GlobalUnsubscribeHdmiAutoLowLatencyModeCapableChanged();
 
+    static void GetAutoLowLatencyModeCapable();
+    static void SetAutoLowLatencyModeCapable();
+    static void GetEdidVersion();
+    static void SetEdidVersion();
+    static void GetHdmiPortInfo();
+
     static bool WaitOnConnectionReady();
 
 private:

--- a/src/sdks/manage/src/cpp/sdk/cpptest/ManageSDKTest.h
+++ b/src/sdks/manage/src/cpp/sdk/cpptest/ManageSDKTest.h
@@ -108,6 +108,11 @@ class ManageSDKTest {
         bool _challengeInput;
     };
 
+    class OnAutoLowLatencyModeCapableChangedNotification : public Firebolt::HDMIInput::IHDMIInput::IOnAutoLowLatencyModeCapableChangedNotification {
+    public:
+        void onAutoLowLatencyModeCapableChanged( const Firebolt::HDMIInput::AutoLowLatencyModeCapableChangedInfo& ) override;
+    };
+
 public:
     ManageSDKTest() = default;
     virtual ~ManageSDKTest() = default;
@@ -183,6 +188,9 @@ public:
     static void WifiConnect();
     static void WifiDisconnect();
 
+    static void GlobalSubscribeHdmiAutoLowLatencyModeCapableChanged();
+    static void GlobalUnsubscribeHdmiAutoLowLatencyModeCapableChanged();
+
     static bool WaitOnConnectionReady();
 
 private:
@@ -199,6 +207,7 @@ private:
     static PinChallengeProvider _pinChallengeProvider;
     static OnSignInNotification _signInNotification;
     static OnSignOutNotification _signOutNotification;
+    static OnAutoLowLatencyModeCapableChangedNotification _autoLowLatencyModeCapableChangedNotification;
 
     static Firebolt::Wifi::AccessPointList _apList;
 };


### PR DESCRIPTION
This PR enhances the Manage SDK test app by adding new test cases. The following functionality has been covered:

* Global subscriber functionality
* HDMI module
