### PR TITLE
fix: Building of Manage SDK (workaround)

### DIFF
--- a/src/sdks/manage/src/cpp/sdk/cpptest/ManageSDKTest.cpp
+++ b/src/sdks/manage/src/cpp/sdk/cpptest/ManageSDKTest.cpp
@@ -830,7 +830,7 @@ void ManageSDKTest::AddLocalizationAdditionalInfo()
 {
     Firebolt::Error error = Firebolt::Error::None;
     std::string key = "testKey";
-    std::string value = "testValue";
+    float value = 1.0f;
 
     Firebolt::IFireboltAccessor::Instance().LocalizationInterface().addAdditionalInfo(key, value, &error);
     if (error == Firebolt::Error::None) {


### PR DESCRIPTION
This is supposed to be a temporary fix until macrofier code investigated and is found why polymorphic functions are not generated.

Issue caused by:
```
diff --git a/src/openrpc/localization.json b/src/openrpc/localization.json
index db92eeb..cc2a803 100644
--- a/src/openrpc/localization.json
+++ b/src/openrpc/localization.json
@@ -298,7 +298,7 @@
           ]
         }
       ],
-      "summary": "Get any platform-specific localization information, in an Map<string, string>",
+      "summary": "Get any platform-specific localization information",
       "params": [],
       "result": {
         "name": "info",
@@ -306,7 +306,7 @@
         "schema": {
           "type": "object",
           "additionalProperties": {
-            "type": "string",
+            "type": ["number", "string", "boolean"],
             "maxLength": 1024
           },
           "maxProperties": 32
@@ -346,9 +346,9 @@
         },
         {
           "name": "value",
-          "summary": "Value to be set for additionalInfo",
+          "summary": "Value to be set for additionalInfo. Value can be a number, string or boolean",
           "schema": {
-            "type": "string"
+            "type": ["number", "string", "boolean"]
           },
           "required": true
         }
```