### PR TITLE
feat: Add Profile.viewingRestrictions method and documentation

### DIFF
--- a/requirements/specifications/profile/parental-controls.md
+++ b/requirements/specifications/profile/parental-controls.md
@@ -20,7 +20,7 @@ To support this, Firebolt shall provide content partners with access to the user
 As an app, I want to...
 
 - Get whether the user has enabled viewing restrictions
-- Get a list of content ratings (and subratings, if applicable) the user has chosen to restrict from viewing
+- Get a list of content ratings (and sub-ratings, if applicable) the user has chosen to restrict from viewing
 - Get whether the user should be able to view unrated content
 - Be notified when the user's viewing restriction preferences have changed
 
@@ -30,23 +30,14 @@ As an app, I want to...
   - [1.1. User Stories](#11-user-stories)
 - [2. Table of Contents](#2-table-of-contents)
 - [3. Constants, Types, and Schemas](#3-constants-types-and-schemas)
-  - [3.1. Content Rating](#31-content-rating)
-  - [3.2. Viewing Restriction](#32-viewing-restriction)
+  - [3.1. Viewing Restriction](#31-viewing-restriction)
+  - [3.2. Content Rating](#32-content-rating)
 - [4. Restrictions](#4-restrictions)
   - [4.1. Viewing Restrictions](#41-viewing-restrictions)
 
 ## 3. Constants, Types, and Schemas
 
-### 3.1. Content Rating
-
-The Firebolt `Profile` module **MUST** have a `ContentRating` object of the following schema:
-
-| Property     | Type       | Required | Description                                                                                                                                          |
-| ------------ | ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `rating`     | `string`   | Yes      | A content rating (e.g. PG-13 for an MPAA rated movie). This may be operator or region dependant.                                                     |
-| `subratings` | `[]string` | Yes      | A list of subratings/content descriptors (e.g. ['V'] for violent content for a US TV based rating scheme). This may be operator or region dependant. |
-
-### 3.2. Viewing Restriction
+### 3.1. Viewing Restriction
 
 The Firebolt `Profile` module **MUST** have a `ViewingRestriction` object of the following schema:
 
@@ -54,6 +45,15 @@ The Firebolt `Profile` module **MUST** have a `ViewingRestriction` object of the
 | --------- | ---------- | -------- | ------------------------------------------------------------------------------------ |
 | `scheme`  | `string`   | Yes      | A rating scheme (e.g. MPAA for US movies). This may be operator or region dependant. |
 | `ratings` | `[]Rating` | Yes      | A list of ratings the user wishes to restrict.                                       |
+
+### 3.2. Content Rating
+
+The Firebolt `Profile` module **MUST** have a `ContentRating` object of the following schema:
+
+| Property     | Type       | Required | Description                                                                                                                                           |
+| ------------ | ---------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rating`     | `string`   | Yes      | A content rating (e.g. PG-13 for an MPAA rated movie). This may be operator or region dependant.                                                      |
+| `subRatings` | `[]string` | Yes      | A list of sub-ratings/content descriptors (e.g. ['V'] for violent content for a US TV based rating scheme). This may be operator or region dependant. |
 
 ## 4. Restrictions
 
@@ -92,7 +92,7 @@ Profile.viewingRestrictions()
 //>         {
 //>             scheme: 'US_TV',
 //>             ratings: [
-//>                 {rating: 'TV-14', subratings: ['V']},
+//>                 {rating: 'TV-14', subRatings: ['V']},
 //>                 {rating: 'TV-MA'},
 //>             ]
 //>         }

--- a/requirements/specifications/profile/parental-controls.md
+++ b/requirements/specifications/profile/parental-controls.md
@@ -1,0 +1,102 @@
+# Parental Controls Requirements
+
+Document Status: Proposed Specification
+
+See [Firebolt Requirements Governance](../../governance.md) for more info.
+
+| Contributor    | Organization |
+| -------------- | ------------ |
+| Andrew Bennett | Sky          |
+| Joe Martin     | Comcast      |
+
+## 1. Overview
+
+Content partners need access to the user's parental control preferences in order to tailor the user experience in accordance to those preferences.
+
+To support this, Firebolt shall provide content partners with access to the user's parental control preferences, allowing them to provide a safe and controlled user experience.  Content partners are expected to honor the parental control preferences as set by the user, gating or outright preventing access to unwanted or sensitive content.
+
+### 1.1. User Stories
+
+As an app, I want to...
+
+- Get whether the user has enabled viewing restrictions
+- Get a list of content ratings (and subratings, if applicable) the user has chosen to restrict from viewing
+- Get whether the user should be able to view unrated content
+- Be notified when the user's viewing restriction preferences have changed
+
+## 2. Table of Contents
+
+- [1. Overview](#1-overview)
+  - [1.1. User Stories](#11-user-stories)
+- [2. Table of Contents](#2-table-of-contents)
+- [3. Constants, Types, and Schemas](#3-constants-types-and-schemas)
+  - [3.1. Content Rating](#31-content-rating)
+  - [3.2. Viewing Restriction](#32-viewing-restriction)
+- [4. Restrictions](#4-restrictions)
+  - [4.1. Viewing Restrictions](#41-viewing-restrictions)
+
+## 3. Constants, Types, and Schemas
+
+### 3.1. Content Rating
+
+The Firebolt `Profile` module **MUST** have a `ContentRating` object of the following schema:
+
+| Property     | Type       | Required | Description                                                                                                                                          |
+| ------------ | ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rating`     | `string`   | Yes      | A content rating (e.g. PG-13 for an MPAA rated movie). This may be operator or region dependant.                                                     |
+| `subratings` | `[]string` | Yes      | A list of subratings/content descriptors (e.g. ['V'] for violent content for a US TV based rating scheme). This may be operator or region dependant. |
+
+### 3.2. Viewing Restriction
+
+The Firebolt `Profile` module **MUST** have a `ViewingRestriction` object of the following schema:
+
+| Property  | Type       | Required | Description                                                                          |
+| --------- | ---------- | -------- | ------------------------------------------------------------------------------------ |
+| `scheme`  | `string`   | Yes      | A rating scheme (e.g. MPAA for US movies). This may be operator or region dependant. |
+| `ratings` | `[]Rating` | Yes      | A list of ratings the user wishes to restrict.                                       |
+
+## 4. Restrictions
+
+Apps need to know which parental control restrictions are in place for the current profile so they can curate the user experience in accordance to those restrictions.
+
+To facilitate this, the `Profile` module will provide convenience methods that allow access to the user's preferred restrictions.
+
+### 4.1. Viewing Restrictions
+
+The `Profile` module **MUST** include a `viewingRestrictions` method that returns an object describing the user's preferred viewing restrictions.
+
+This method's response **MUST** support the following properties:
+
+| Property                 | Type                   | Required | Description                                               |
+| ------------------------ | ---------------------- | -------- | --------------------------------------------------------- |
+| `enabled`                | `boolean`              | Yes      | Whether or not viewing restrictions are currently enabled |
+| `restrictions`           | `[]ViewingRestriction` | Yes      |                                                           |
+| `restrictUnratedContent` | `boolean`              | Yes      | Whether or not unrated content should be viewable         |
+
+This method **MUST** have a corresponding `onViewingRestrictionsChanged` event to notify listeners after a change to any properties have been made and that change has taken effect.
+
+Access to these methods **MUST** require the `use` role of the `xrn:firebolt:capability:profile:viewingrestrictions` capability.
+
+```javascript
+Profile.viewingRestrictions()
+//> {
+//>     enabled: true,
+//>     restrictions: [
+//>         {
+//>             scheme: 'MPAA',
+//>             ratings: [
+//>                 {rating: 'R'},
+//>                 {rating: 'NC-17'}
+//>             ]
+//>         },
+//>         {
+//>             scheme: 'US_TV',
+//>             ratings: [
+//>                 {rating: 'TV-14', subratings: ['V']},
+//>                 {rating: 'TV-MA'},
+//>             ]
+//>         }
+//>     ],
+//>     restrictUnratedContent: true
+//> }
+```

--- a/src/openrpc/profile.json
+++ b/src/openrpc/profile.json
@@ -1,210 +1,212 @@
 {
-  "openrpc": "1.2.4",
-  "info": {
-    "title": "Profile",
-    "description": "Methods for getting information about the current user/account profile",
-    "version": "0.0.0"
-  },
-  "methods": [
-    {
-      "name": "approveContentRating",
-      "tags": [
-        {
-          "name": "capabilities",
-          "x-uses": [
-            "xrn:firebolt:capability:approve:content"
-          ]
-        }
-      ],
-      "summary": "Verifies that the current profile should have access to mature/adult content.",
-      "params": [],
-      "result": {
-        "name": "allow",
-        "summary": "Whether or not to allow access",
-        "schema": {
-          "type": "boolean"
-        }
-      },
-      "examples": [
-        {
-          "name": "Default Example",
-          "params": [],
-          "result": {
-            "name": "allow",
-            "value": false
-          }
-        }
-      ]
+    "openrpc": "1.2.4",
+    "info": {
+        "title": "Profile",
+        "description": "Methods for getting information about the current user/account profile",
+        "version": "0.0.0"
     },
-    {
-      "name": "approvePurchase",
-      "tags": [
+    "methods": [
         {
-          "name": "capabilities",
-          "x-uses": [
-            "xrn:firebolt:capability:approve:purchase"
-          ]
-        }
-      ],
-      "summary": "Verifies that the current profile should have access to making purchases.",
-      "params": [],
-      "result": {
-        "name": "allow",
-        "summary": "Whether or not to allow access",
-        "schema": {
-          "type": "boolean"
-        }
-      },
-      "examples": [
-        {
-          "name": "Default Example",
-          "params": [],
-          "result": {
-            "name": "allow",
-            "value": false
-          }
-        }
-      ]
-    },
-    {
-      "name": "flags",
-      "tags": [
-        {
-          "name": "capabilities",
-          "x-uses": [
-            "xrn:firebolt:capability:profile:flags"
-          ]
-        }
-      ],
-      "summary": "Get a map of profile flags for the current session.",
-      "params": [],
-      "result": {
-        "name": "flags",
-        "summary": "The profile flags.",
-        "schema": {
-          "$ref": "https://meta.comcast.com/firebolt/types#/definitions/FlatMap"
-        }
-      },
-      "examples": [
-        {
-          "name": "Default Example",
-          "params": [],
-          "result": {
-            "name": "flags",
-            "value": {
-              "userExperience": "1000"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "viewingRestrictions",
-      "summary": "The profile's preferred viewing restrictions.",
-      "params": [],
-      "tags": [
-        {
-          "name": "property:readonly"
+            "name": "approveContentRating",
+            "tags": [
+                {
+                    "name": "capabilities",
+                    "x-uses": [
+                        "xrn:firebolt:capability:approve:content"
+                    ]
+                }
+            ],
+            "summary": "Verifies that the current profile should have access to mature/adult content.",
+            "params": [],
+            "result": {
+                "name": "allow",
+                "summary": "Whether or not to allow access",
+                "schema": {
+                    "type": "boolean"
+                }
+            },
+            "examples": [
+                {
+                    "name": "Default Example",
+                    "params": [],
+                    "result": {
+                        "name": "allow",
+                        "value": false
+                    }
+                }
+            ]
         },
         {
-          "name": "capabilities",
-          "x-uses": [
-            "xrn:firebolt:capability:profile:viewingrestrictions"
-          ]
-        }
-      ],
-      "result": {
-        "name": "viewingRestrictions",
-        "summary": "The current viewing restrictions",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "restrictions": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ViewingRestriction"
-              }
-            }
-          },
-          "required": [
-            "enabled",
-            "restrictions"
-          ]
-        }
-      },
-      "errors": [],
-      "examples": [
-        {
-          "name": "Content with an MPAA R-rating and US TV TV-14-V is restricted",
-          "params": [],
-          "result": {
-            "name": "Default Result",
-            "value": {
-              "enabled": true,
-              "restrictions": [
+            "name": "approvePurchase",
+            "tags": [
                 {
-                  "scheme": "MPAA",
-                  "ratings": [
-                    {
-                      "rating": "R"
+                    "name": "capabilities",
+                    "x-uses": [
+                        "xrn:firebolt:capability:approve:purchase"
+                    ]
+                }
+            ],
+            "summary": "Verifies that the current profile should have access to making purchases.",
+            "params": [],
+            "result": {
+                "name": "allow",
+                "summary": "Whether or not to allow access",
+                "schema": {
+                    "type": "boolean"
+                }
+            },
+            "examples": [
+                {
+                    "name": "Default Example",
+                    "params": [],
+                    "result": {
+                        "name": "allow",
+                        "value": false
                     }
-                  ]
+                }
+            ]
+        },
+        {
+            "name": "flags",
+            "tags": [
+                {
+                    "name": "capabilities",
+                    "x-uses": [
+                        "xrn:firebolt:capability:profile:flags"
+                    ]
+                }
+            ],
+            "summary": "Get a map of profile flags for the current session.",
+            "params": [],
+            "result": {
+                "name": "flags",
+                "summary": "The profile flags.",
+                "schema": {
+                    "$ref": "https://meta.comcast.com/firebolt/types#/definitions/FlatMap"
+                }
+            },
+            "examples": [
+                {
+                    "name": "Default Example",
+                    "params": [],
+                    "result": {
+                        "name": "flags",
+                        "value": {
+                            "userExperience": "1000"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "viewingRestrictions",
+            "summary": "The profile's preferred viewing restrictions.",
+            "params": [],
+            "tags": [
+                {
+                    "name": "property:readonly"
                 },
                 {
-                  "scheme": "US TV",
-                  "ratings": [
-                    {
-                      "rating": "TV-14",
-                      "subratings": [
-                        "V"
-                      ]
-                    }
-                  ]
+                    "name": "capabilities",
+                    "x-uses": [
+                        "xrn:firebolt:capability:profile:viewingrestrictions"
+                    ]
                 }
-              ]
-            }
-          }
+            ],
+            "result": {
+                "name": "viewingRestrictions",
+                "summary": "The current viewing restrictions",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "restrictions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/ViewingRestriction"
+                            }
+                        }
+                    },
+                    "required": [
+                        "enabled",
+                        "restrictions"
+                    ]
+                }
+            },
+            "errors": [],
+            "examples": [
+                {
+                    "name": "Content with an MPAA R-rating and US TV TV-14-V is restricted",
+                    "params": [],
+                    "result": {
+                        "name": "Default Result",
+                        "value": {
+                            "enabled": true,
+                            "restrictions": [
+                                {
+                                    "scheme": "MPAA",
+                                    "ratings": [
+                                        {
+                                            "rating": "R"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "scheme": "US_TV",
+                                    "ratings": [
+                                        {
+                                            "rating": "TV-14",
+                                            "subRatings": [
+                                                "V"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
         }
-      ]
+    ],
+    "components": {
+        "schemas": {
+            "ContentRating": {
+                "description": "The rating and subrating for content.",
+                "type": "object",
+                "properties": {
+                    "rating": {
+                        "description": "The rating to be restricted. Refer to operator documentation for supported values.",
+                        "type": "string"
+                    },
+                    "subRatings": {
+                        "description": "A list of sub-ratings to be restricted. Refer to operator documentation for supported values.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "ViewingRestriction": {
+                "description": "The content viewing restriction.",
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "description": "The scheme for the restriction (e.g. MPAA for US movies). Scheme values may be region or operator dependant; refer to operator documentation for the scheme values supported on your targeted platform.",
+                        "type": "string"
+                    },
+                    "ratings": {
+                        "description": "A list of content ratings to be restricted.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ContentRating"
+                        }
+                    }
+                }
+            }
+        }
     }
-  ],
-  "components": {
-    "schemas": {
-      "ContentRating": {
-        "description": "The rating and subrating for content.",
-        "type": "object",
-        "properties": {
-          "rating": {
-            "type": "string"
-          },
-          "subratings": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "ViewingRestriction": {
-        "description": "The content viewing restriction.",
-        "type": "object",
-        "properties": {
-          "scheme": {
-            "description": "The scheme for the restriction (such as MPAA for US movies). This value may be platform or operator dependant.",
-            "type": "string"
-          },
-          "ratings": {
-            "description": "A list of content ratings to be restricted.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ContentRating"
-            }
-          }
-        }
-      }
-    }
-  }
 }

--- a/src/openrpc/profile.json
+++ b/src/openrpc/profile.json
@@ -138,7 +138,7 @@
             "errors": [],
             "examples": [
                 {
-                    "name": "Content with an MPAA R-rating and US TV TV-14-V is restricted",
+                    "name": "Viewing restrictions that disallow content with an MPAA R or US TV-14-V rating",
                     "params": [],
                     "result": {
                         "name": "Default Result",

--- a/src/openrpc/profile.json
+++ b/src/openrpc/profile.json
@@ -33,8 +33,8 @@
             "name": "allow",
             "value": false
           }
-        }            
-      ]    
+        }
+      ]
     },
     {
       "name": "approvePurchase",
@@ -63,8 +63,8 @@
             "name": "allow",
             "value": false
           }
-        }            
-      ]    
+        }
+      ]
     },
     {
       "name": "flags",
@@ -97,6 +97,114 @@
           }
         }
       ]
+    },
+    {
+      "name": "viewingRestrictions",
+      "summary": "The profile's preferred viewing restrictions.",
+      "params": [],
+      "tags": [
+        {
+          "name": "property:readonly"
+        },
+        {
+          "name": "capabilities",
+          "x-uses": [
+            "xrn:firebolt:capability:profile:viewingrestrictions"
+          ]
+        }
+      ],
+      "result": {
+        "name": "viewingRestrictions",
+        "summary": "The current viewing restrictions",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "restrictions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ViewingRestriction"
+              }
+            }
+          },
+          "required": [
+            "enabled",
+            "restrictions"
+          ]
+        }
+      },
+      "errors": [],
+      "examples": [
+        {
+          "name": "Content with an MPAA R-rating and US TV TV-14-V is restricted",
+          "params": [],
+          "result": {
+            "name": "Default Result",
+            "value": {
+              "enabled": true,
+              "restrictions": [
+                {
+                  "scheme": "MPAA",
+                  "ratings": [
+                    {
+                      "rating": "R"
+                    }
+                  ]
+                },
+                {
+                  "scheme": "US TV",
+                  "ratings": [
+                    {
+                      "rating": "TV-14",
+                      "subratings": [
+                        "V"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
-  ]
+  ],
+  "components": {
+    "schemas": {
+      "ContentRating": {
+        "description": "The rating and subrating for content.",
+        "type": "object",
+        "properties": {
+          "rating": {
+            "type": "string"
+          },
+          "subratings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ViewingRestriction": {
+        "description": "The content viewing restriction.",
+        "type": "object",
+        "properties": {
+          "scheme": {
+            "description": "The scheme for the restriction (such as MPAA for US movies). This value may be platform or operator dependant.",
+            "type": "string"
+          },
+          "ratings": {
+            "description": "A list of content ratings to be restricted.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContentRating"
+            }
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Adds a `Profile.viewingRestrictions` method with event, allowing apps to access the user's parental control viewing restrictions.