### PR TITLE
fix: Types not listed in Discovery shared schema documentation

### DIFF
--- a/src/openrpc/discovery.json
+++ b/src/openrpc/discovery.json
@@ -74,7 +74,7 @@
 					"name": "result",
 					"required": true,
 					"schema": {
-						"$ref": "https://meta.rdkcentral.com/firebolt/schemas/discovery#/definitions/EntityInfoResult"
+						"$ref": "#/components/schemas/EntityInfoResult"
 					},
 					"summary": "The entityInfo data."
 				}
@@ -448,7 +448,7 @@
 					"name": "result",
 					"required": true,
 					"schema": {
-						"$ref": "https://meta.rdkcentral.com/firebolt/schemas/discovery#/definitions/PurchasedContentResult"
+						"$ref": "#/components/schemas/PurchasedContentResult"
 					},
 					"summary": "The data for the purchasedContent"
 				}
@@ -1768,7 +1768,7 @@
 						"type": "object",
 						"properties": {
 							"result": {
-								"$ref": "https://meta.rdkcentral.com/firebolt/schemas/discovery#/definitions/EntityInfoResult"
+								"$ref": "#/components/schemas/EntityInfoResult"
 							}
 						}
 					}
@@ -1862,7 +1862,7 @@
 						"type": "object",
 						"properties": {
 							"result": {
-								"$ref": "https://meta.rdkcentral.com/firebolt/schemas/discovery#/definitions/PurchasedContentResult"
+								"$ref": "#/components/schemas/PurchasedContentResult"
 							}
 						}
 					}

--- a/src/schemas/discovery.json
+++ b/src/schemas/discovery.json
@@ -2,55 +2,10 @@
   "title": "Discovery",
   "$id": "https://meta.rdkcentral.com/firebolt/schemas/discovery",
   "anyOf": [
-    {
-      "$ref": "#/definitions/PurchasedContentResult"
-    }
+      {"$ref": "#/definitions/InterestType"},
+      {"$ref": "#/definitions/InterestReason"}
   ],
   "definitions": {
-    "PurchasedContentResult": {
-      "title": "PurchasedContentResult",
-      "type": "object",
-      "properties": {
-        "expires": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "totalCount": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "entries": {
-          "type": "array",
-          "items": {
-            "$ref": "https://meta.rdkcentral.com/firebolt/schemas/entertainment#/definitions/EntityInfo"
-          }
-        }
-      },
-      "required": ["expires", "totalCount", "entries"],
-      "additionalProperties": false
-    },
-    "EntityInfoResult": {
-      "title": "EntityInfoResult",
-      "description": "The result for an `entityInfo()` push or pull.",
-      "type": "object",
-      "properties": {
-        "expires": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "entity": {
-          "$ref": "https://meta.rdkcentral.com/firebolt/schemas/entertainment#/definitions/EntityInfo"
-        },
-        "related": {
-          "type": "array",
-          "items": {
-            "$ref": "https://meta.rdkcentral.com/firebolt/schemas/entertainment#/definitions/EntityInfo"
-          }
-        }
-      },
-      "required": ["expires", "entity"],
-      "additionalProperties": false
-    },
     "InterestType": {
       "title": "InterestType",
       "type": "string",


### PR DESCRIPTION
The definitions of "PurchasedContentResult" and "EntityInfoResult" exist in the files firebolt-apis/src/schemas/discovery.json and firebolt-apis/src/openrpc/discovery.json. Since both types are not shared but local to the Discovery Openrpc document, we can then remove the duplicates from the shared schema file - firebolt-apis/src/schemas/discovery.json