### PR TITLE
fix: Remove platform static module from manage+discovery sdks

### DIFF
--- a/src/sdks/discovery/package.json
+++ b/src/sdks/discovery/package.json
@@ -7,7 +7,7 @@
 	"type": "module",
 	"scripts": {
 		"validate": "npx firebolt-openrpc validate --platformApi ./dist/firebolt-discovery-open-rpc.json --appApi ./dist/firebolt-discovery-app-open-rpc.json",
-		"sdk": "npx firebolt-openrpc sdk --platformApi ./dist/firebolt-discovery-open-rpc.json --appApi ./dist/firebolt-discovery-app-open-rpc.json --template ./src/js --output ./build/javascript/src --static-module Platform",
+		"sdk": "npx firebolt-openrpc sdk --platformApi ./dist/firebolt-discovery-open-rpc.json --appApi ./dist/firebolt-discovery-app-open-rpc.json --template ./src/js --output ./build/javascript/src",
 		"cpp": "npm run cpp:compile && npm run cpp:install",
 		"cpp:compile": "npx firebolt-openrpc sdk --platformApi ./dist/firebolt-discovery-open-rpc.json --appApi ./dist/firebolt-discovery-app-open-rpc.json --template ./src/cpp --output ./build/cpp/src --static-module Platform --language ../../../node_modules/@firebolt-js/openrpc/languages/cpp",
 		"cpp:install": "chmod +x ./build/cpp/src/scripts/install.sh && sdkVersion=$(npm run -s getVersion) && ./build/cpp/src/scripts/install.sh -i ./build/cpp/src -s ./build/cpp/src/ -m discovery -v $sdkVersion",

--- a/src/sdks/manage/package.json
+++ b/src/sdks/manage/package.json
@@ -7,7 +7,7 @@
 	"type": "module",
 	"scripts": {
 		"validate": "npx firebolt-openrpc validate --platformApi ./dist/firebolt-manage-open-rpc.json --appApi ./dist/firebolt-manage-app-open-rpc.json",
-		"sdk": "npx firebolt-openrpc sdk --platformApi ./dist/firebolt-manage-open-rpc.json --appApi ./dist/firebolt-manage-app-open-rpc.json --template ./src/js --output ./build/javascript/src --static-module Platform",
+		"sdk": "npx firebolt-openrpc sdk --platformApi ./dist/firebolt-manage-open-rpc.json --appApi ./dist/firebolt-manage-app-open-rpc.json --template ./src/js --output ./build/javascript/src",
 		"cpp": "npm run cpp:compile && npm run cpp:install",
 		"cpp:compile": "npx firebolt-openrpc sdk --platformApi ./dist/firebolt-manage-open-rpc.json --appApi ./dist/firebolt-manage-app-open-rpc.json --template ./src/cpp --output ./build/cpp/src --static-module Platform --language ../../../node_modules/@firebolt-js/openrpc/languages/cpp",
 		"cpp:install": "chmod +x ./build/cpp/src/scripts/install.sh && sdkVersion=$(npm run -s getVersion) && ./build/cpp/src/scripts/install.sh -i ./build/cpp/src -s ./build/cpp/src/ -m manage -v $sdkVersion",


### PR DESCRIPTION
The static platform module is not required in manage and discovery sdks