### PR TITLE
fix: Update templates to use gateway

### DIFF
--- a/src/sdks/core/src/js/sdk/Device/index.mjs
+++ b/src/sdks/core/src/js/sdk/Device/index.mjs
@@ -22,7 +22,7 @@
 
 function version() {
   return new Promise( (resolve, reject) => {
-      Transport.send('device', 'version').then( v => {
+      Gateway.request('device', 'version').then( v => {
           v = v || {}
           v.sdk = v.sdk || {}
           v.sdk.major = parseInt('${major}')

--- a/src/sdks/core/src/js/sdk/Device/index.mjs
+++ b/src/sdks/core/src/js/sdk/Device/index.mjs
@@ -22,7 +22,7 @@
 
 function version() {
   return new Promise( (resolve, reject) => {
-      Gateway.request('device', 'version').then( v => {
+      Gateway.request('device.version', {}).then( v => {
           v = v || {}
           v.sdk = v.sdk || {}
           v.sdk.major = parseInt('${major}')

--- a/src/sdks/core/src/js/sdk/Lifecycle/index.mjs
+++ b/src/sdks/core/src/js/sdk/Lifecycle/index.mjs
@@ -34,7 +34,7 @@ async function ready() {
   await prioritize('Lifecycle', (event, value) => {
     store._current = event
   })
-  readyRes =await Transport.send('lifecycle', 'ready', {})
+  readyRes =await Gateway.request('lifecycle', 'ready', {})
   setTimeout(_ => {
     logReady()
   })
@@ -49,7 +49,7 @@ function state() {
 
 function finished() {
   if (store.current === 'unloading') {
-    return Transport.send('lifecycle', 'finished')
+    return Gateway.request('lifecycle', 'finished')
   } else {
     throw 'Cannot call finished() except when in the unloading transition'
   }

--- a/src/sdks/core/src/js/sdk/Lifecycle/index.mjs
+++ b/src/sdks/core/src/js/sdk/Lifecycle/index.mjs
@@ -34,7 +34,7 @@ async function ready() {
   await prioritize('Lifecycle', (event, value) => {
     store._current = event
   })
-  readyRes =await Gateway.request('lifecycle', 'ready', {})
+  readyRes = await Gateway.request('lifecycle.ready', {})
   setTimeout(_ => {
     logReady()
   })
@@ -49,7 +49,7 @@ function state() {
 
 function finished() {
   if (store.current === 'unloading') {
-    return Gateway.request('lifecycle', 'finished')
+    return Gateway.request('lifecycle.finished', {})
   } else {
     throw 'Cannot call finished() except when in the unloading transition'
   }

--- a/src/sdks/core/src/js/sdk/Metrics/index.mjs
+++ b/src/sdks/core/src/js/sdk/Metrics/index.mjs
@@ -21,15 +21,15 @@
 /* ${INITIALIZATION} */
 
 function ready() {
-  return Transport.send('metrics', 'ready', {})
+  return Gateway.request('metrics', 'ready', {})
 }
 
 function signIn() {
-  return Transport.send('metrics', 'signIn', {})
+  return Gateway.request('metrics', 'signIn', {})
 }
 
 function signOut() {
-  return Transport.send('metrics', 'signOut', {})
+  return Gateway.request('metrics', 'signOut', {})
 }
 
 

--- a/src/sdks/core/src/js/sdk/Metrics/index.mjs
+++ b/src/sdks/core/src/js/sdk/Metrics/index.mjs
@@ -21,15 +21,15 @@
 /* ${INITIALIZATION} */
 
 function ready() {
-  return Gateway.request('metrics', 'ready', {})
+  return Gateway.request('metrics.ready', {})
 }
 
 function signIn() {
-  return Gateway.request('metrics', 'signIn', {})
+  return Gateway.request('metrics.signIn', {})
 }
 
 function signOut() {
-  return Gateway.request('metrics', 'signOut', {})
+  return Gateway.request('metrics.signOut', {})
 }
 
 


### PR DESCRIPTION
Update static templates to use Gateway.request instead of Transport.send which was the 1.0 way of doing things.