### PR TITLE
build: Update setup-node in github action

### DIFF
--- a/.github/workflows/cxx-build.yml
+++ b/.github/workflows/cxx-build.yml
@@ -58,7 +58,7 @@ jobs:
           repo-token: ${{ secrets.SEMANTIC_RELEASE_BOT_PAT }}
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
       - name: Set up NPM token

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -27,7 +27,7 @@ jobs:
           repo-token: ${{ secrets.SEMANTIC_RELEASE_BOT_PAT }}
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
       - name: Set up NPM token


### PR DESCRIPTION
setup-node@v2 used outdated version of actions/cache and github actions started to fail with the following error:
```
  Run actions/setup-node@v2
  Attempt to resolve LTS alias from manifest...
  Found in cache @ /opt/hostedtoolcache/node/22.15.0/x64
  /opt/hostedtoolcache/node/22.15.0/x64/bin/npm config get cache
  /home/runner/.npm
  Error: Cache service responded with 422
```