### PR TITLE
feat: Add distribution ID API

### DIFF
--- a/requirements/specifications/identification/account-device-identification.md
+++ b/requirements/specifications/identification/account-device-identification.md
@@ -41,9 +41,9 @@ The `Device` module will provide methods allowing apps to query for various iden
 
 The `Device` module **MUST** have an `distributionId` method that returns a string value denoting a group of devices as managed by a distributor.
 
-Access to this method **MUST** require the `use` role of the `xrn:firebolt:capability:device:distributorid` capability.
+Access to this method **MUST** require the `use` role of the `xrn:firebolt:capability:device:distributionid` capability.
 
 ```javascript
-Device.distributorId()
-//> "cableco-australia"
+Device.distributionId()
+//> "kangaroo-cable-west"
 ```

--- a/requirements/specifications/identification/account-device-identification.md
+++ b/requirements/specifications/identification/account-device-identification.md
@@ -1,0 +1,49 @@
+# Account and Device Identification Requirements
+
+Document Status: Proposed Specification
+
+See [Firebolt Requirements Governance](../../governance.md) for more info.
+
+| Contributor    | Organization |
+| -------------- | ------------ |
+| Andrew Bennett | Sky          |
+| Joe Martin     | Comcast      |
+
+## 1. Overview
+
+Content partners want to understand various identifiers and attributes associated with the device and/or its operator's back-office system.
+
+This information can primarily be used to provide apps with details on the current runtime environment for telemetry purposes and rich data analysis.
+
+This information may also be used to deploy self-configuring apps that can deliver experiences tailored to a specific subset of users.
+
+Other back-office attributes may also be used to leverage additional platform features that are heavily reliant on such identifiers (e.g. advertising and commerce).
+
+### 1.1. User Stories
+
+As an app, I want to...
+
+- Get the operator name of the device
+
+## 2. Table of Contents
+
+- [1. Overview](#1-overview)
+  - [1.1. User Stories](#11-user-stories)
+- [2. Table of Contents](#2-table-of-contents)
+- [4. Device Identification Attributes](#4-device-identification-attributes)
+  - [4.1. Distribution ID](#41-distribution-id)
+
+## 4. Device Identification Attributes
+
+The `Device` module will provide methods allowing apps to query for various identifying attributes of the device.
+
+### 4.1. Distribution ID
+
+The `Device` module **MUST** have an `distributionId` method that returns a string value denoting a group of devices as managed by a distributor.
+
+Access to this method **MUST** require the `use` role of the `xrn:firebolt:capability:device:distributorid` capability.
+
+```javascript
+Device.distributorId()
+//> "cableco-australia"
+```

--- a/src/json/firebolt-specification.json
+++ b/src/json/firebolt-specification.json
@@ -60,6 +60,9 @@
     "xrn:firebolt:capability:advertising:identifier": {
       "level": "could"
     },
+    "xrn:firebolt:capability:device:distributionid": {
+      "level": "could"
+    },
     "xrn:firebolt:capability:discovery:sign-in-status": {
       "level": "could"
     },

--- a/src/openrpc/device.json
+++ b/src/openrpc/device.json
@@ -73,6 +73,39 @@
       ]
     },
     {
+      "name": "distributionId",
+      "summary": "Get the distribution ID for the device.  This may be a subset of the distributor.  For example, a distributor may have multiple distribution IDs for different regions or customer groups.",
+      "params": [],
+      "tags": [
+        {
+          "name": "property:immutable"
+        },
+        {
+          "name": "capabilities",
+          "x-uses": [
+            "xrn:firebolt:capability:device:distributionid"
+          ]
+        }
+      ],
+      "result": {
+        "name": "distributionId",
+        "summary": "The distribution ID",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "examples": [
+        {
+          "name": "Get the distribution ID",
+          "params": [],
+          "result": {
+            "name": "Default Result",
+            "value": "cableco-australia"
+          }
+        }
+      ]
+    },
+    {
       "name": "platform",
       "summary": "Get a platform identifier for the device. This API should be used to correlate metrics on the device only and cannot be guaranteed to have consistent responses across platforms.",
       "params": [],

--- a/src/openrpc/device.json
+++ b/src/openrpc/device.json
@@ -74,7 +74,7 @@
     },
     {
       "name": "distributionId",
-      "summary": "Get the distribution ID for the device.  This may be a subset of the distributor.  For example, a distributor may have multiple distribution IDs for different regions or customer groups.",
+      "summary": "Get the distribution ID assigned to the device which denotes a specific grouping of devices managed by a distributor.  Each distributor may have multiple distribution IDs each being tied to a specific region or customer segment.  Consult distributor documentation for more information on possible values.",
       "params": [],
       "tags": [
         {
@@ -96,11 +96,19 @@
       },
       "examples": [
         {
-          "name": "Get the distribution ID",
+          "name": "Get the distribution ID for a group of devices managed by distributor 'Kangaroo Cable'",
           "params": [],
           "result": {
             "name": "Default Result",
-            "value": "cableco-australia"
+            "value": "kangaroo-east"
+          }
+        },
+        {
+          "name": "Get the distribution ID for another group of devices managed by distributor 'Kangaroo Cable'",
+          "params": [],
+          "result": {
+            "name": "Default Result",
+            "value": "kangaroo-west"
           }
         }
       ]

--- a/src/sdks/core/sdk.config.json
+++ b/src/sdks/core/sdk.config.json
@@ -46,6 +46,7 @@
         {
             "module": "Device",
             "use": [
+                "xrn:firebolt:capability:device:distributionid",
                 "xrn:firebolt:capability:device:distributor",
                 "xrn:firebolt:capability:device:id",
                 "xrn:firebolt:capability:device:info",


### PR DESCRIPTION
Adds a new `Device.distributionId` method denoting a specific grouping of devices under a distributor.