### PR TITLE
feat: Add age policy param

### DIFF
--- a/src/openrpc/discovery.json
+++ b/src/openrpc/discovery.json
@@ -8,7 +8,7 @@
   "methods": [
     {
       "name": "policy",
-      "summary": "get the discovery policy",
+      "summary": "Get the discovery policy",
       "params": [],
       "tags": [
         {
@@ -581,6 +581,21 @@
             "type": "string",
             "format": "date-time"
           }
+        },
+        {
+          "name": "options",
+          "summary": "Additional options for the watched content",
+          "schema": {
+            "type": "object",
+            "properties":  {
+              "agePolicy": {
+                "summary": "The age policy that describes the watched content.  For example, content that is directed towards children should have the appropriate child policy supplied to ensure any appropriate child data protections are enforced.  See distributor documentation for further details.",
+                "schema": {
+                  "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
+                }
+              }
+            }
+          }
         }
       ],
       "result": {
@@ -592,7 +607,7 @@
       },
       "examples": [
         {
-          "name": "Notifying the platform of watched content",
+          "name": "Notify the platform of watched content",
           "params": [
             {
               "name": "entityId",
@@ -609,6 +624,37 @@
             {
               "name": "watchedOn",
               "value": "2021-04-23T18:25:43.511Z"
+            }
+          ],
+          "result": {
+            "name": "success",
+            "value": true
+          }
+        },
+        {
+          "name": "Notify the platform that child-directed content was watched",
+          "params": [
+            {
+              "name": "entityId",
+              "value": "partner.com/entity/123"
+            },
+            {
+              "name": "progress",
+              "value": 0.95
+            },
+            {
+              "name": "completed",
+              "value": true
+            },
+            {
+              "name": "watchedOn",
+              "value": "2021-04-23T18:25:43.511Z"
+            },
+            {
+              "name": "options",
+              "value": {
+                "agePolicy": "app:child"
+              }
             }
           ],
           "result": {
@@ -1004,8 +1050,30 @@
         }
       },
       "examples": [
+{
+  "name": "Launch the 'Foo' app to it's home screen.",
+  "params": [
+    {
+      "name": "appId",
+      "value": "foo"
+    },
+    {
+      "name": "intent",
+      "value": {
+        "action": "home",
+        "context": {
+          "source": "voice"
+        }
+      }
+    }
+  ],
+          "result": {
+            "name": "success",
+            "value": true
+          }
+        },
         {
-          "name": "Launch the 'Foo' app to it's home screen.",
+          "name": "Launch the 'Foo' app to it's home screen where the launch intent came from a child-directed browse menu.",
           "params": [
             {
               "name": "appId",
@@ -1016,7 +1084,7 @@
               "value": {
                 "action": "home",
                 "context": {
-                  "source": "voice"
+                  "source": "browse"
                 }
               }
             }

--- a/src/openrpc/discovery.json
+++ b/src/openrpc/discovery.json
@@ -583,18 +583,10 @@
           }
         },
         {
-          "name": "options",
-          "summary": "Additional options for the watched content",
+          "name": "agePolicy",
+          "description": "The age policy associated with the watch event. The age policy describes the age groups to which content may be directed.",
           "schema": {
-            "type": "object",
-            "required": [
-              "agePolicy"
-            ],
-            "properties":  {
-              "agePolicy": {
-                "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
-              }
-            }
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],

--- a/src/openrpc/discovery.json
+++ b/src/openrpc/discovery.json
@@ -589,10 +589,7 @@
             "type": "object",
             "properties":  {
               "agePolicy": {
-                "summary": "The age policy that describes the watched content.  For example, content that is directed towards children should have the appropriate child policy supplied to ensure any appropriate child data protections are enforced.  See distributor documentation for further details.",
-                "schema": {
-                  "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
-                }
+                "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
               }
             }
           }

--- a/src/openrpc/discovery.json
+++ b/src/openrpc/discovery.json
@@ -1050,23 +1050,23 @@
         }
       },
       "examples": [
-{
-  "name": "Launch the 'Foo' app to it's home screen.",
-  "params": [
-    {
-      "name": "appId",
-      "value": "foo"
-    },
-    {
-      "name": "intent",
-      "value": {
-        "action": "home",
-        "context": {
-          "source": "voice"
-        }
-      }
-    }
-  ],
+        {
+          "name": "Launch the 'Foo' app to it's home screen.",
+          "params": [
+            {
+              "name": "appId",
+              "value": "foo"
+            },
+            {
+              "name": "intent",
+              "value": {
+                "action": "home",
+                "context": {
+                  "source": "voice"
+                }
+              }
+            }
+          ],
           "result": {
             "name": "success",
             "value": true

--- a/src/openrpc/discovery.json
+++ b/src/openrpc/discovery.json
@@ -587,6 +587,9 @@
           "summary": "Additional options for the watched content",
           "schema": {
             "type": "object",
+            "required": [
+              "agePolicy"
+            ],
             "properties":  {
               "agePolicy": {
                 "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"

--- a/src/openrpc/discovery.json
+++ b/src/openrpc/discovery.json
@@ -643,10 +643,8 @@
               "value": "2021-04-23T18:25:43.511Z"
             },
             {
-              "name": "options",
-              "value": {
-                "agePolicy": "app:child"
-              }
+              "name": "agePolicy",
+              "value": "app:child"
             }
           ],
           "result": {

--- a/src/openrpc/metrics.json
+++ b/src/openrpc/metrics.json
@@ -189,10 +189,8 @@
               "value": "abc"
             },
             {
-              "name": "options",
-              "value": {
-                "agePolicy": "app:child"
-              }
+              "name": "agePolicy",
+              "value": "app:child"
             }
           ],
           "result": {

--- a/src/openrpc/metrics.json
+++ b/src/openrpc/metrics.json
@@ -1272,6 +1272,9 @@
         "title": "MetricOptions",
         "description": "Additional options, tags, or labels to include with a metrics call.",
         "type": "object",
+        "required": [
+          "agePolicy"
+        ],
         "properties": {
           "agePolicy": {
             "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"

--- a/src/openrpc/metrics.json
+++ b/src/openrpc/metrics.json
@@ -88,7 +88,7 @@
             "name": "success",
             "value": true
           }
-        }        
+        }
       ]
     },
     {
@@ -121,7 +121,7 @@
             "name": "success",
             "value": true
           }
-        }        
+        }
       ]
     },
     {
@@ -143,6 +143,13 @@
             "type": "string"
           },
           "required": false
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -160,7 +167,7 @@
             "name": "success",
             "value": true
           }
-        },  
+        },
         {
           "name": "Send startContent metric w/ entity",
           "params": [
@@ -173,7 +180,26 @@
             "name": "success",
             "value": true
           }
-        } 
+        },
+        {
+          "name": "Send startContent metric and notify the platform that the content is child-directed",
+          "params": [
+            {
+              "name": "entityId",
+              "value": "abc"
+            },
+            {
+              "name": "options",
+              "value": {
+                "agePolicy": "app:child"
+              }
+            }
+          ],
+          "result": {
+            "name": "success",
+            "value": true
+          }
+        }
       ]
     },
     {
@@ -195,6 +221,13 @@
             "type": "string"
           },
           "required": false
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -212,7 +245,7 @@
             "name": "success",
             "value": true
           }
-        },  
+        },
         {
           "name": "Send stopContent metric w/ entity",
           "params": [
@@ -225,7 +258,7 @@
             "name": "success",
             "value": true
           }
-        }         
+        }
       ]
     },
     {
@@ -247,6 +280,13 @@
             "type": "string"
           },
           "required": true
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -268,7 +308,7 @@
             "name": "success",
             "value": true
           }
-        },  
+        },
         {
           "name": "Send startContent metric w/ entity",
           "params": [
@@ -281,7 +321,7 @@
             "name": "success",
             "value": true
           }
-        }         
+        }
       ]
     },
     {
@@ -323,6 +363,13 @@
             "$ref": "https://meta.comcast.com/firebolt/types#/definitions/FlatMap"
           },
           "required": false
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -348,9 +395,9 @@
             "name": "success",
             "value": true
           }
-        }     
+        }
       ]
-    }, 
+    },
     {
       "name": "error",
       "tags": [
@@ -401,7 +448,14 @@
           "schema": {
             "$ref": "https://meta.comcast.com/firebolt/types#/definitions/FlatMap"
           },
-          "required": false          
+          "required": false
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -435,7 +489,7 @@
             "name": "success",
             "value": true
           }
-        }      
+        }
       ]
     },
     {
@@ -457,6 +511,13 @@
             "type": "string"
           },
           "required": true
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -479,7 +540,7 @@
             "value": true
           }
         }
-      ]      
+      ]
     },
     {
       "name": "mediaPlay",
@@ -500,6 +561,13 @@
             "type": "string"
           },
           "required": true
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -522,7 +590,7 @@
             "value": true
           }
         }
-      ]  
+      ]
     },
     {
       "name": "mediaPlaying",
@@ -543,6 +611,13 @@
             "type": "string"
           },
           "required": true
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -565,7 +640,7 @@
             "value": true
           }
         }
-      ]  
+      ]
     },
     {
       "name": "mediaPause",
@@ -586,6 +661,13 @@
             "type": "string"
           },
           "required": true
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -608,7 +690,7 @@
             "value": true
           }
         }
-      ]  
+      ]
     },
     {
       "name": "mediaWaiting",
@@ -629,6 +711,13 @@
             "type": "string"
           },
           "required": true
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -651,7 +740,7 @@
             "value": true
           }
         }
-      ]  
+      ]
     },
     {
       "name": "mediaProgress",
@@ -680,6 +769,13 @@
             "$ref": "#/components/schemas/MediaPosition"
           },
           "required": true
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -706,7 +802,7 @@
             "value": true
           }
         }
-      ]  
+      ]
     },
     {
       "name": "mediaSeeking",
@@ -735,6 +831,13 @@
             "$ref": "#/components/schemas/MediaPosition"
           },
           "required": true
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -761,7 +864,7 @@
             "value": true
           }
         }
-      ]  
+      ]
     },
     {
       "name": "mediaSeeked",
@@ -790,6 +893,13 @@
             "$ref": "#/components/schemas/MediaPosition"
           },
           "required": true
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -816,7 +926,7 @@
             "value": true
           }
         }
-      ]  
+      ]
     },
     {
       "name": "mediaRateChange",
@@ -845,6 +955,13 @@
             "type": "number"
           },
           "required": true
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -871,7 +988,7 @@
             "value": true
           }
         }
-      ]  
+      ]
     },
     {
       "name": "mediaRenditionChange",
@@ -924,6 +1041,13 @@
             "type": "string"
           },
           "required": false
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -962,7 +1086,7 @@
             "value": true
           }
         }
-      ]  
+      ]
     },
     {
       "name": "mediaEnded",
@@ -983,6 +1107,13 @@
             "type": "string"
           },
           "required": true
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -1035,6 +1166,13 @@
             "$ref": "#/components/schemas/EventObject"
           },
           "required": true
+        },
+        {
+          "name": "options",
+          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "schema": {
+            "$ref": "#/components/schemas/MetricOptions"
+          }
         }
       ],
       "result": {
@@ -1062,7 +1200,7 @@
             "name": "result",
             "value": null
           }
-        }     
+        }
       ]
     },
     {
@@ -1129,6 +1267,16 @@
             "maximum": 86400
           }
         ]
+      },
+      "MetricOptions": {
+        "title": "MetricOptions",
+        "description": "Additional options, tags, or labels to include with a metrics call.",
+        "type": "object",
+        "properties": {
+          "agePolicy": {
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
+          }
+        }
       },
       "ErrorType": {
         "title": "ErrorType",

--- a/src/openrpc/metrics.json
+++ b/src/openrpc/metrics.json
@@ -145,10 +145,10 @@
           "required": false
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -223,10 +223,10 @@
           "required": false
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -282,10 +282,10 @@
           "required": true
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -365,10 +365,10 @@
           "required": false
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -451,10 +451,10 @@
           "required": false
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -513,10 +513,10 @@
           "required": true
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -563,10 +563,10 @@
           "required": true
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -613,10 +613,10 @@
           "required": true
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -663,10 +663,10 @@
           "required": true
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -713,10 +713,10 @@
           "required": true
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -771,10 +771,10 @@
           "required": true
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -833,10 +833,10 @@
           "required": true
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -895,10 +895,10 @@
           "required": true
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -957,10 +957,10 @@
           "required": true
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -1043,10 +1043,10 @@
           "required": false
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -1109,10 +1109,10 @@
           "required": true
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -1168,10 +1168,10 @@
           "required": true
         },
         {
-          "name": "options",
-          "summary": "Additional options, tags, or labels to apply to this metric call.",
+          "name": "agePolicy",
+          "summary": "The age policy to associate with the metrics event. The age policy describes the age group to which content is directed.",
           "schema": {
-            "$ref": "#/components/schemas/MetricOptions"
+            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
           }
         }
       ],
@@ -1267,19 +1267,6 @@
             "maximum": 86400
           }
         ]
-      },
-      "MetricOptions": {
-        "title": "MetricOptions",
-        "description": "Additional options, tags, or labels to include with a metrics call.",
-        "type": "object",
-        "required": [
-          "agePolicy"
-        ],
-        "properties": {
-          "agePolicy": {
-            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy"
-          }
-        }
       },
       "ErrorType": {
         "title": "ErrorType",

--- a/src/schemas/intents.json
+++ b/src/schemas/intents.json
@@ -178,6 +178,10 @@
                     "properties": {
                         "source": {
                             "type": "string"
+                        },
+                        "agePolicy": {
+                            "$ref": "https://meta.comcast.com/firebolt/policies#/definitions/AgePolicy",
+                            "description": "The age policy associated with the intent. The age policy describes the age groups to which content is directed. For example, content launched from a child-directed menu should have the appropriate child policy attached, which may inform an app or service to enable enhanced data protections or features."
                         }
                     }
                 }
@@ -618,7 +622,7 @@
                                 }
                             },
                             "additionalProperties": false
-                        }   
+                        }
                     }
                 }
             ],
@@ -757,7 +761,7 @@
                                         "type": "object",
                                         "maxProperties": 0
                                     }
-                                }                                
+                                }
                             }
                         }
                     }
@@ -1300,7 +1304,7 @@
                     }
                 }
             ]
-        },           
+        },
         "ScrollIntent": {
             "description": "A Firebolt compliant representation of a user intention to interact with their device in a way analogous to pressing remote directional pad buttons.",
             "title": "ScrollIntent",
@@ -1450,7 +1454,7 @@
                                     "value": {
                                         "type": "number",
                                         "minimum": -50,
-                                        "maximum": 50        
+                                        "maximum": 50
                                     }
                                 }
                             },
@@ -1607,7 +1611,7 @@
                     "context": {
                         "source": "voice"
                     }
-                }                
+                }
             ]
         },
         "MicrophoneIntent": {
@@ -1769,7 +1773,7 @@
                     }
                 }
             ]
-        },        
+        },
         "ReplayIntent": {
             "description": "A Firebolt compliant representation of a user intention to replay content.",
             "title": "ReplayIntent",
@@ -1797,7 +1801,7 @@
                     }
                 }
             ]
-        },       
+        },
         "StopIntent": {
             "description": "A Firebolt compliant representation of a user intention to stop content.",
             "title": "StopIntent",
@@ -1825,7 +1829,7 @@
                     }
                 }
             ]
-        },                  
+        },
         "PlaybackSpeedIntent": {
             "description": "A Firebolt compliant representation of a user intention to change the speed of in-progress playback.",
             "title": "PlaybackSpeedIntent",
@@ -1935,7 +1939,7 @@
                     "context": {
                         "source": "voice"
                     }
-                }                
+                }
             ]
         },
         "RewindIntent": {
@@ -1991,9 +1995,9 @@
                     "context": {
                         "source": "voice"
                     }
-                }                
+                }
             ]
-        },        
+        },
         "SeekIntent": {
             "description": "A Firebolt compliant representation of a user intention to seek to a different time for in-progress playback.",
             "title": "SeekIntent",
@@ -2232,14 +2236,14 @@
                                     "required": [ "toggle" ]
                                 },
                                 "if": {
-                                    "required": [ "relative" ]                                    
+                                    "required": [ "relative" ]
                                 },
                                 "then": {
                                     "properties": {
                                         "speed": {
                                             "type": "integer",
                                             "minimum": -10,
-                                            "maximum": 10        
+                                            "maximum": 10
                                         }
                                     }
                                 },
@@ -2248,7 +2252,7 @@
                                         "speed": {
                                             "type": "integer",
                                             "exclusiveMinimum": 0,
-                                            "maximum": 10        
+                                            "maximum": 10
                                         }
                                     }
                                 }
@@ -2288,7 +2292,7 @@
                     "context": {
                         "source": "voice"
                     }
-                },                
+                },
                 {
                     "action": "voice-guidance",
                     "data": {
@@ -2418,7 +2422,7 @@
                     }
                 }
             ]
-        },        
+        },
         "ScreenMagnificationIntent": {
             "description": "A Firebolt compliant representation of a user intention to turn screen magnification on or off.",
             "title": "ScreenMagnificationIntent",
@@ -2483,7 +2487,7 @@
                     "context": {
                         "source": "voice"
                     }
-                },                
+                },
                 {
                     "action": "screen-magnification",
                     "data": {
@@ -2501,7 +2505,7 @@
                     "context": {
                         "source": "voice"
                     }
-                }                
+                }
             ]
         },
         "MessageIntent": {
@@ -2543,7 +2547,7 @@
                 }
             ]
         },
- 
+
         "Identifier": {
             "type": "string"
         },

--- a/src/schemas/policies.json
+++ b/src/schemas/policies.json
@@ -1,0 +1,16 @@
+{
+    "$id": "https://meta.comcast.com/firebolt/policies",
+    "title": "Policies",
+    "definitions": {
+        "AgePolicy": {
+            "title": "AgePolicy",
+            "description": "The policy that describes various age groups to which content is directed.",
+            "type": "string",
+            "enum": [
+              "app:adult",
+              "app:child",
+              "app:teen"
+            ]
+        }
+    }
+}

--- a/src/schemas/policies.json
+++ b/src/schemas/policies.json
@@ -4,9 +4,11 @@
     "definitions": {
         "AgePolicy": {
             "title": "AgePolicy",
-            "description": "The policy that describes various age groups to which content is directed.",
-            "oneOf": [
-                { "type":"string" },
+            "description": "The policy that describes various age groups to which content is directed. See distributor documentation for further details.",
+            "anyOf": [
+                {
+                    "type": "string"
+                },
                 {
                     "type": "string",
                     "enum": [

--- a/src/schemas/policies.json
+++ b/src/schemas/policies.json
@@ -5,11 +5,16 @@
         "AgePolicy": {
             "title": "AgePolicy",
             "description": "The policy that describes various age groups to which content is directed.",
-            "type": "string",
-            "enum": [
-              "app:adult",
-              "app:child",
-              "app:teen"
+            "oneOf": [
+                { "type":"string" },
+                {
+                    "type": "string",
+                    "enum": [
+                        "app:adult",
+                        "app:child",
+                        "app:teen"
+                    ]
+                }
             ]
         }
     }


### PR DESCRIPTION
Adds an `AgePolicy` schema, which can be attached to various metrics and intents.

The schema defines some reserved values: `app:child`, `app:teen`, and `app:adult` but an operator can otherwise use custom values here.

The following  methods have been updated to support an `agePolicy` param:

```
Discovery.watched
Intents.*
Metrics.* (except for appInfo)
```

