### PR TITLE
test: With a fix in mock-fb, events can be emitted as events

### DIFF
--- a/src/cpp/test/component/deviceTest.cpp
+++ b/src/cpp/test/component/deviceTest.cpp
@@ -218,10 +218,8 @@ TEST_F(DeviceTest, subscribeOnAudioChanged)
         });
     verifyEventSubscription(id);
     // Trigger the event from the mock server
-    // triggerEvent("Device.onAudioChanged",
-    //             R"({ "stereo": true, "dolbyDigital5.1": true, "dolbyDigital5.1+": true, "dolbyAtmos": true })");
-    triggerRaw(
-        R"({"method":"device.audioChanged","params":{ "stereo": true, "dolbyDigital5.1": true, "dolbyDigital5.1+": true, "dolbyAtmos": true }})");
+    triggerEvent("Device.onAudioChanged",
+                 R"({ "stereo": true, "dolbyDigital5.1": true, "dolbyDigital5.1+": true, "dolbyAtmos": true })");
 
     verifyEventReceived(mtx, cv, eventReceived);
     // Unsubscribe from the event
@@ -302,8 +300,7 @@ TEST_F(DeviceTest, subscribeOnNetworkChanged)
         });
     verifyEventSubscription(id);
     // Trigger the event from the mock server
-    // triggerEvent("Device.onNetworkChanged", R"({ "state": "connected", "type": "wifi"})");
-    triggerRaw(R"({"method":"device.networkChanged","params":{ "state": "connected", "type": "wifi"}})");
+    triggerEvent("Device.onNetworkChanged", R"({ "state": "connected", "type": "wifi"})");
 
     verifyEventReceived(mtx, cv, eventReceived);
     // Unsubscribe from the event

--- a/src/cpp/test/component/deviceTest.cpp
+++ b/src/cpp/test/component/deviceTest.cpp
@@ -218,7 +218,7 @@ TEST_F(DeviceTest, subscribeOnAudioChanged)
         });
     verifyEventSubscription(id);
     // Trigger the event from the mock server
-    triggerEvent("Device.onAudioChanged",
+    triggerEvent("Device.audioChanged",
                  R"({ "stereo": true, "dolbyDigital5.1": true, "dolbyDigital5.1+": true, "dolbyAtmos": true })");
 
     verifyEventReceived(mtx, cv, eventReceived);
@@ -245,7 +245,7 @@ TEST_F(DeviceTest, subscribeOnDeviceNameChanged)
         });
     verifyEventSubscription(id);
     // Trigger the event from the mock server
-    triggerEvent("Device.onDeviceNameChanged", R"({ "name": "Test Device Name" })");
+    triggerEvent("Device.deviceNameChanged", R"({ "name": "Test Device Name" })");
 
     verifyEventReceived(mtx, cv, eventReceived);
     // Unsubscribe from the event
@@ -272,7 +272,7 @@ TEST_F(DeviceTest, subscribeOnHdcpChanged)
         });
     verifyEventSubscription(id);
     // Trigger the event from the mock server
-    triggerEvent("Device.onHdcpChanged", R"({ "version": 2, "state": 1 })");
+    triggerEvent("Device.hdcpChanged", R"({ "version": 2, "state": 1 })");
 
     verifyEventReceived(mtx, cv, eventReceived);
     // Unsubscribe from the event
@@ -300,7 +300,7 @@ TEST_F(DeviceTest, subscribeOnNetworkChanged)
         });
     verifyEventSubscription(id);
     // Trigger the event from the mock server
-    triggerEvent("Device.onNetworkChanged", R"({ "state": "connected", "type": "wifi"})");
+    triggerEvent("Device.networkChanged", R"({ "state": "connected", "type": "wifi"})");
 
     verifyEventReceived(mtx, cv, eventReceived);
     // Unsubscribe from the event

--- a/src/cpp/test/component/lifecycle2Test.cpp
+++ b/src/cpp/test/component/lifecycle2Test.cpp
@@ -81,8 +81,7 @@ TEST_F(LifecycleTest, subscribeOnState)
     verifyEventSubscription(id);
 
     // Trigger the event from the mock server
-    triggerEvent("Lifecycle2.onStateChanged",
-        R"([{"focused":true,"newState":"paused","oldState":"initializing"}])");
+    triggerEvent("Lifecycle2.stateChanged", R"([{"focused":true,"newState":"paused","oldState":"initializing"}])");
 
     verifyEventReceived(mtx, cv, eventReceived);
     // Unsubscribe from the event

--- a/src/cpp/test/component/lifecycle2Test.cpp
+++ b/src/cpp/test/component/lifecycle2Test.cpp
@@ -81,9 +81,8 @@ TEST_F(LifecycleTest, subscribeOnState)
     verifyEventSubscription(id);
 
     // Trigger the event from the mock server
-    // triggerEvent("Lifecycle2.onStateChanged", R"([{"focused":true,"newState":"paused","oldState":"initializing"}])");
-    triggerRaw(
-        R"({"method":"lifecycle2.stateChanged","params":[{"focused":true,"newState":"paused","oldState":"initializing"}]})");
+    triggerEvent("Lifecycle2.onStateChanged",
+        R"([{"focused":true,"newState":"paused","oldState":"initializing"}])");
 
     verifyEventReceived(mtx, cv, eventReceived);
     // Unsubscribe from the event

--- a/src/cpp/test/component/utils.cpp
+++ b/src/cpp/test/component/utils.cpp
@@ -100,7 +100,23 @@ void triggerRaw(const std::string &payload)
 void triggerEvent(const std::string &method, const std::string &params)
 {
     nlohmann::json eventMessage;
-    eventMessage["method"] = method;
+    size_t dotPos = method.find('.');
+    if (dotPos != std::string::npos && method.size() > dotPos + 1)
+    {
+        std::string module = method.substr(0, dotPos);
+        std::string event = method.substr(dotPos + 1);
+        if (event.find("on") != 0)
+        {
+            if (!event.empty())
+                event[0] = static_cast<char>(std::toupper(event[0]));
+            event = "on" + event;
+        }
+        eventMessage["method"] = module + "." + event;
+    }
+    else
+    {
+        eventMessage["method"] = method;
+    }
     eventMessage["result"] = nlohmann::json::parse(params);
 
     httpPost("http://localhost:3333/api/v1/event", eventMessage.dump());


### PR DESCRIPTION
All CTs for events works correctly when mock-firebolt used from : https://github.com/tomasz-blasz/mock-firebolt/tree/feat/raw-message