### PR TITLE
test: Update payload to JSON-RPC compliant params with an array

### DIFF
--- a/src/cpp/test/component/lifecycleTest.cpp
+++ b/src/cpp/test/component/lifecycleTest.cpp
@@ -79,7 +79,7 @@ TEST_F(LifecycleTest, subscribeOnState)
     verifyEventSubscription(id);
 
     // Trigger the event from the mock server
-    triggerEvent("Lifecycle2.onStateChanged", R"([{"newState":"paused","oldState":"initializing"}])");
+    triggerEvent("Lifecycle2.onStateChanged", R"({"value":[{"newState":"paused","oldState":"initializing"}]})");
 
     verifyEventReceived(mtx, cv, eventReceived);
     // Unsubscribe from the event

--- a/src/cpp/test/component/localizationTest.cpp
+++ b/src/cpp/test/component/localizationTest.cpp
@@ -108,7 +108,7 @@ TEST_F(LocalizationTest, subscribeOnPreferredAudioLanguagesChanged)
     EXPECT_TRUE(id.has_value()) << "error on id";
 
     // Trigger the event from the mock server
-    triggerEvent("Localization.onPreferredAudioLanguagesChanged", R"(["spa","eng"])");
+    triggerEvent("Localization.onPreferredAudioLanguagesChanged", R"({"value":["spa","eng"]})");
 
     verifyEventReceived(mtx, cv, eventReceived);
 

--- a/src/cpp/test/unit/localizationTest.cpp
+++ b/src/cpp/test/unit/localizationTest.cpp
@@ -21,8 +21,6 @@
 #include "localization_impl.h"
 #include "mock_helper.h"
 
-#define USE_LOCAL_RESPONSE
-
 class LocalizationTest : public ::testing::Test, protected MockBase
 {
 protected:
@@ -31,13 +29,8 @@ protected:
 
 TEST_F(LocalizationTest, Country)
 {
-#ifdef USE_LOCAL_RESPONSE
-    nlohmann::json expectedValue = "US";
-    mock_with_response("Localization.country", expectedValue);
-#else
     auto expectedValue = jsonEngine.get_value("Localization.country").get<std::string>();
     mock("Localization.country");
-#endif
 
     auto result = localizationImpl_.country();
     ASSERT_TRUE(result) << "error on get";
@@ -60,13 +53,8 @@ TEST_F(LocalizationTest, PreferredAudioLanguages)
 
 TEST_F(LocalizationTest, PresentationLanguage)
 {
-#ifdef USE_LOCAL_RESPONSE
-    nlohmann::json expectedValue = "US";
-    mock_with_response("Localization.presentationLanguage", expectedValue);
-#else
     auto expectedValue = jsonEngine.get_value("Localization.presentationLanguage").get<std::string>();
     mock("Localization.presentationLanguage");
-#endif
 
     auto result = localizationImpl_.presentationLanguage();
     ASSERT_TRUE(result) << "error on get";


### PR DESCRIPTION
`params` being an array means a list of positional parameters for function call, to pass an array as a value, it has to be wrapped in an object.

[JSON-RPC spec](https://www.jsonrpc.org/specification)

> params
> A Structured value that holds the parameter values to be used during the invocation of the method. This member MAY be omitted.
>
>
> 4.2 Parameter Structures
> If present, parameters for the rpc call MUST be provided as a Structured value. Either by-position through an Array or by-name through an Object.
>
> by-position: params MUST be an Array, containing the values in the Server expected order.
> by-name: params MUST be an Object, with member names that match the Server expected parameter names. The absence of expected names MAY result in an error being generated. The names MUST match exactly, including case, to the method's expected parameters.