### PR TITLE
feat: Add network connection status

### DIFF
--- a/requirements/specifications/network/network.md
+++ b/requirements/specifications/network/network.md
@@ -1,0 +1,47 @@
+# Network Requirements
+
+Document Status: Proposed Specification
+
+See [Firebolt Requirements Governance](../../governance.md) for more info.
+
+| Contributor | Organization |
+| ----------- | ------------ |
+| Joe Martin  | Comcast      |
+
+## 1. Overview
+
+Applications want to query for the device's network connectivity state and capabilities, which will allow them to monitor for network connection changes and provide an appropriate experience (such as gracefully stop playback when the network connection is reported as down).
+
+To support this, Firebolt shall provide applications with access to various networking APIs that allow them to query for various properties of the device's local network connection.
+
+### 1.1. User Stories
+
+As an app, I want to...
+
+- Get a simple report of the device's network connection state
+- Be notified when the device's connection to the local network has changed
+
+## 2. Table of Contents
+
+- [1. Overview](#1-overview)
+  - [1.1. User Stories](#11-user-stories)
+- [2. Table of Contents](#2-table-of-contents)
+- [3. Network](#3-network)
+  - [3.1. Connected State](#31-connected-state)
+
+## 3. Network
+
+The `Network` module will provide methods to various network properties, such as the network connection state.
+
+### 3.1. Connected State
+
+The `Activation` module **MUST** include a `connected` method that returns whether or not the device has an enabled and usable connection to the local network.
+
+This method **MUST** have a corresponding `onConnectedChanged` event to notify listeners when a change to the network connection has occured.
+
+Access to these methods **MUST** require the `use` role of the `xrn:firebolt:capability:network:connected` capability.
+
+```javascript
+Network.connected()
+//> true
+```

--- a/src/openrpc/network.json
+++ b/src/openrpc/network.json
@@ -1,0 +1,51 @@
+{
+  "openrpc": "1.2.4",
+  "info": {
+    "title": "Network",
+    "description": "A module for returning details about the device's network connection and networking capabilities.",
+    "version": "0.0.0"
+  },
+  "methods": [
+    {
+      "name": "connected",
+      "summary": "Get whether or not the device has a valid connection to the local network",
+      "params": [],
+      "tags": [
+        {
+          "name": "property:readonly"
+        },
+        {
+          "name": "capabilities",
+          "x-uses": [
+            "xrn:firebolt:capability:network:connected"
+          ]
+        }
+      ],
+      "result": {
+        "name": "connected",
+        "summary": "The network connection state of the device",
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "examples": [
+        {
+          "name": "The device has an active, valid network connection",
+          "params": [],
+          "result": {
+            "name": "Default Result",
+            "value": true
+          }
+        },
+                {
+          "name": "The device is offline",
+          "params": [],
+          "result": {
+            "name": "Default Result",
+            "value": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/sdks/core/sdk.config.json
+++ b/src/sdks/core/sdk.config.json
@@ -119,6 +119,12 @@
             ]
         },
         {
+            "module": "Network",
+            "use": [
+                "xrn:firebolt:capability:network:connected"
+            ]
+        },
+        {
             "module": "Parameters",
             "use": [
                 "xrn:firebolt:capability:lifecycle:state"


### PR DESCRIPTION
Adds a new network connection status API, to simply return whether or not the device has an active, valid connection to the local network.

```javascript
Network.connected()
//> true
```
