### PR TITLE
fix(ci): Fix dependabot PR failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,14 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
       production-dependencies:
         dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -87,7 +87,7 @@ jobs:
           npx semantic-release
 
       - name: Dry-run mono-artifact
-        if: (github.ref_name == 'main' && github.event_name != 'workflow_dispatch') || github.event_name == 'pull_request'
+        if: ((github.ref_name == 'main' && github.event_name != 'workflow_dispatch') || github.event_name == 'pull_request') && github.actor != 'dependabot[bot]'
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_BOT_PAT }} # <-- Allows semantic-release-bot to push changes to protected branches
         run: npx semantic-release --dry-run


### PR DESCRIPTION
- release-github.yml: skip dry-run for dependabot[bot] PRs since SEMANTIC_RELEASE_BOT_PAT is unavailable to Dependabot by GitHub policy
- dependabot.yml: restrict groups to patch/minor updates only so major version bumps get individual PRs (and the manual-review label) rather than being lumped together and failing the build