### PR TITLE
ci: Group major Dependabot updates and auto-merge safe dev-only majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,35 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # Major version groups — related packages must move together
+      commitlint:
+        patterns:
+          - "@commitlint/*"
+        update-types:
+          - "major"
+      semantic-release-ecosystem:
+        patterns:
+          - "semantic-release"
+          - "@semantic-release/*"
+          - "@saithodev/semantic-release-*"
+        update-types:
+          - "major"
+      jest-ecosystem:
+        patterns:
+          - "jest"
+          - "jest-*"
+          - "@jest/*"
+        update-types:
+          - "major"
+      tooling:
+        patterns:
+          - "husky"
+          - "nopt"
+          - "mkdirp"
+          - "ajv"
+          - "ajv-*"
+        update-types:
+          - "major"
     # These advisories affect brace-expansion@5.0.4 and picomatch@4.0.3 which are
     # bundledDependencies inside npm@11.12.1 (the latest npm@11 as of this writing).
     # They cannot be fixed without a patch release from the npm project itself.

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,30 +23,53 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      # Auto-approve patch and minor updates only; major updates require manual review
+      # Auto-approve patch/minor updates, and major updates for dev-only safe groups
       - name: Approve PR
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          (
+            steps.metadata.outputs.update-type == 'version-update:semver-major' &&
+            (
+              steps.metadata.outputs.dependency-group == 'commitlint' ||
+              steps.metadata.outputs.dependency-group == 'semantic-release-ecosystem' ||
+              steps.metadata.outputs.dependency-group == 'jest-ecosystem' ||
+              steps.metadata.outputs.dependency-group == 'tooling'
+            )
+          )
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Auto-merge patch and minor updates (waits for CI to pass)
-      - name: Enable auto-merge for patch/minor updates
+      # Auto-merge patch/minor and approved dev-only major groups (waits for CI to pass)
+      - name: Enable auto-merge
         id: auto-merge
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          (
+            steps.metadata.outputs.update-type == 'version-update:semver-major' &&
+            (
+              steps.metadata.outputs.dependency-group == 'commitlint' ||
+              steps.metadata.outputs.dependency-group == 'semantic-release-ecosystem' ||
+              steps.metadata.outputs.dependency-group == 'jest-ecosystem' ||
+              steps.metadata.outputs.dependency-group == 'tooling'
+            )
+          )
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Label major updates so they're easy to find for manual review
+      # Label remaining major updates (e.g. typescript) for manual review
       - name: Label major updates for manual review
-        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-major' &&
+          steps.metadata.outputs.dependency-group != 'commitlint' &&
+          steps.metadata.outputs.dependency-group != 'semantic-release-ecosystem' &&
+          steps.metadata.outputs.dependency-group != 'jest-ecosystem' &&
+          steps.metadata.outputs.dependency-group != 'tooling'
         run: gh pr edit "$PR_URL" --add-label "major-dependency-update"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
dependabot.yml:
- Add commitlint, semantic-release-ecosystem, jest-ecosystem, tooling groups for major version updates so related packages arrive in one PR

dependabot-auto-merge.yml:
- Auto-approve and merge major bumps for the four safe dev-only groups (commitlint, semantic-release-ecosystem, jest-ecosystem, tooling)
- Only flag as manual-review majors that are not in those groups (e.g. typescript)