### PR TITLE
fix(ci): Skip Release job for Dependabot PRs and harden label step

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -70,6 +70,7 @@ jobs:
           steps.metadata.outputs.dependency-group != 'semantic-release-ecosystem' &&
           steps.metadata.outputs.dependency-group != 'jest-ecosystem' &&
           steps.metadata.outputs.dependency-group != 'tooling'
+        continue-on-error: true
         run: gh pr edit "$PR_URL" --add-label "major-dependency-update"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   release:
     name: Release
+    if: github.actor != 'dependabot[bot]'
     permissions:
       contents: read
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Two separate CI failures on Dependabot PRs (#531, #532, #533):

1. **Release job** — fails at `Checkout` because `SEMANTIC_RELEASE_BOT_PAT` secret is not available to Dependabot PRs (GitHub security restriction).
2. **dependabot job** — fails at "Label major updates for manual review" because the label `major-dependency-update` did not exist in the repo.

## Fixes

- Add `if: github.actor != 'dependabot[bot]'` to the `release` job in `release-github.yml` so it is skipped entirely for Dependabot PRs.
- Add `continue-on-error: true` to the label step in `dependabot-auto-merge.yml` as a resilience guard against missing labels.
- The `major-dependency-update` label has been created in the repo separately.