### PR TITLE
fix(security): Override picomatch to 4.0.4 via tinyglobby scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12515,7 +12515,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12524,7 +12524,9 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,10 @@
     "typescript": "~5.4.0"
   },
   "overrides": {
-    "@semantic-release/npm": "^13.1.5"
+    "@semantic-release/npm": "^13.1.5",
+    "tinyglobby": {
+      "picomatch": "^4.0.4"
+    }
   },
   "keywords": [
     "firebolt",


### PR DESCRIPTION
## Problem

Dependabot cannot auto-fix the `picomatch 4.0.3` vulnerability because none of the upstream packages (`semantic-release`, `@semantic-release/npm`, `@saithodev/semantic-release-backmerge`) have released versions that use `picomatch 4.0.4` yet.

## Fix

- Add a scoped npm `overrides` entry in `package.json`:
  ```json
  "tinyglobby": { "picomatch": "^4.0.4" }
  ```
  This forces only `tinyglobby`'s picomatch to 4.0.4 without affecting `anymatch`/`micromatch` which legitimately need picomatch `^2.x`.
- Patch `package-lock.json` to update the single vulnerable entry (`node_modules/npm/node_modules/tinyglobby/node_modules/picomatch`) from `4.0.3` → `4.0.4` with the correct resolved URL and integrity hash (verified from npm registry).